### PR TITLE
A collected number of enhancements

### DIFF
--- a/knop9/knoplibs/knop_base.lasso
+++ b/knop9/knoplibs/knop_base.lasso
@@ -1,5 +1,5 @@
 ﻿<?LassoScript
-log_critical('loading knop_base from LassoApp')
+log_critical('loading knop_base')
 /**!All Knop custom types should have this type as parent type. This is to be able to identify all registered knop types.
 	*/
 define knop_knoptype => type {
@@ -15,6 +15,12 @@ define knop_base => type {
 	/*
 
 	CHANGE NOTES
+	2013-01-31	JC	Major code cleanup of minor details.
+					Removed all semicolons
+					Changed local('xyz' to local(xyz
+					Replaced += with -> append
+					Changed old style if to brackets
+					Replaced iterate with query expression
 	2012-07-02	JC	Improved speed for method varname. Prev: ca 500 micros to run, now ca 55 micros. Note that varname does not work if the knop object is stored in a local
 	2012-05-18	JC	Removed an old style colon syntax call
 	2011-05-30	JC	Fixed bug in regards to calling error_msg
@@ -41,132 +47,136 @@ define knop_base => type {
 
 	*/
 
-	data public version = '2012-07-02'
-	data public debug_trace::array=array
-	data public _debug_trace::array=array
-	data public instance_unique=null
-	data public instance_varname=null
+	data public version = '2013-01-31'
+	data public debug_trace::array = array
+	data public _debug_trace::array = array
+	data public instance_unique = null
+	data public instance_varname = null
 	data public tagtime::integer				// time for entire tag in ms
 	data public tagtime_tagname::tag
-	data public error_code=0
-	data public error_msg=string
-	data public error_lang=null // must be defined as knop_lang in each type instead, to avoid recursion
+	data public error_code = 0
+	data public error_msg = string
+	data public error_lang = null // must be defined as knop_lang in each type instead, to avoid recursion
 
 /* is this needed anymore? Jolle 2011-01-26
 	public ondeserialize =>{
 
-		local('description' = 'Recreates transient variables after coming back from a session');
-		self -> properties -> first -> insert('_debug_trace'=array);
+		local(description = 'Recreates transient variables after coming back from a session')
+		self -> properties -> first -> insert('_debug_trace' = array)
 	}
 */
 
+	/**!
+	help
+	Auto generates an overview of all member tags of a type, with all parameters specified for each member tag.
+	*/
+	public help(html::boolean = false, xhtml::boolean = false) => {
 
-
-	public help(html::boolean=false, xhtml::boolean=false) => {
-
-		local('description'='Auto generates an overview of all member tags of a type, with all parameters specified for each member tag.')
+		local(description = 'Auto generates an overview of all member tags of a type, with all parameters specified for each member tag.')
 
 //		log_critical('curr params: '+params)
-		local('endslash' = self->xhtml(params) ? ' /' | '')
-		local('eol'= (#html || #endslash =='') ? ('<br' + #endslash + '>\n') | '\n')
+		local(endslash = self->xhtml(params) ? ' /' | '')
+		local(eol = (#html || #endslash == '') ? ('<br' + #endslash + '>\n') | '\n')
 
-		local('output'=string)
-		local('tags'=array)
-		local('description'=string)
-		local('parameters'=string)
+		local(output = string)
+		local(tags = array)
+		local(parameters = string)
 
-		#output += (self -> type) + ' - version ' + (self -> 'version') + '\n'
-		#output += (self -> 'description') + '\n\n'
-		iterate(self->listmethods)
-			#tags->insert(loop_value)
-		/iterate
-		if(self -> parent -> type != null) // this doesn't work
-			iterate(self -> parent -> listmethods)
-				#tags -> insert(loop_value)
-			/iterate
-		/if
+		#output -> append((self -> type) + ' - version ' + (self -> 'version') + '\n' + (self -> 'description') + '\n\n')
+		with listmethod in self->listmethods do {
+			#tags->insert(#listmethod)
+		}
+		if(self -> parent -> type != null) => { // this doesn't work
+			with listmethod in self -> parent -> listmethods do {
+				#tags -> insert(#listmethod)
+			}
+		}
 
 //		log_critical('found tags: '+#tags+' which is a '+#tags->type)
 		#tags -> sort
 
-		iterate(#tags )
+		with tag in #tags do {
 			#parameters = string
-			#output += '-> ' + (loop_value -> methodname)
-			#description=(loop_value->paramdescs)
+			#output -> append('-> ' + (#tag -> methodname))
+			#description = (#tag -> paramdescs)
 
-			iterate(loop_value->paramdescs)
-				if(#description !>> ('-' + loop_value))
-					//#parameters += '-' + (loop_value -> get(1)) + ' (' (loop_value -> isrequired ? 'required' | 'optional')
-						+ (loop_value -> get(2) != 'null' && loop_value -> get(2) -> size ? ' ' + (loop_value -> get(2)))  + ')\n'
-					#parameters += '-' + (loop_value -> get(1)) + ' (' + (loop_value -> get(2) != 'null' && loop_value -> get(2) -> size ? ' ' + (loop_value -> get(2)))  + ')\n'
-				/if
-			/iterate;
-			#output += (#description -> size || #parameters -> size ? '\n' + #description)
-			#output += (#description >> 'Parameters:' ?  '\n')
-			#output += (#description !>> 'Parameters:' && #parameters -> size ? '\nParameters:\n')
-			#output += (#parameters -> size ? #parameters)
+			with desc in #tag -> paramdescs do {
+				if(#description !>> ('-' + #desc)) => {
+					//#parameters += '-' + (#desc -> get(1)) + ' (' (#desc -> isrequired ? 'required' | 'optional')
+//						+ (#desc -> get(2) != 'null' && #desc -> get(2) -> size ? ' ' + (#desc -> get(2)))  + ')\n'
+					#parameters -> append('-' + (#desc -> get(1)) + ' (' + (#desc -> get(2) != 'null' && #desc -> get(2) -> size ? ' ' + (#desc -> get(2)))  + ')\n')
+				}
+			}
+			#output -> append(#description -> size || #parameters -> size ? '\n' + #description)
+			#output -> append(#description >> 'Parameters:' ?  '\n')
+			#output -> append(#description !>> 'Parameters:' && #parameters -> size ? '\nParameters:\n')
+			#output -> append(#parameters -> size ? #parameters)
 			#output -> removetrailing('\n')
-			#output += '\n\n'
-		/iterate
+			#output -> append('\n\n')
+		}
 
-		if((local_defined('html') && #html != false) || (local_defined('xhtml') && #xhtml != false))
+		if((local_defined('html') && #html != false) || (local_defined('xhtml') && #xhtml != false)) => {
 			#output = encode_html(#output)
 			// normalize line breaks and convert to <br>
 			#output -> replace('\r\n', '\n') & replace('\r', '\n') & replace('\n', #eol + '\n')
-		/if
-		return(#output)
+		}
+		return #output
 	}
 
-
-	public xhtml(params='') => {
-
-		local('description'='Internal. Finds out if xhtml output should be used. Looks at doctype unless -xhtml is specified \
+	/**!
+	xhtml
+	Internal. Finds out if xhtml output should be used. Looks at doctype unless -xhtml is specified \
 			in the params array. The result is cached in a page variable. \n\
-			Looking at doctype doesn\'t work when using atbegin driven solutions since content_body isn\'t filled with the page buffer until the page has already been processed.  ');
+			Looking at doctype doesn\'t work when using atbegin driven solutions since content_body isn\'t filled with the page buffer until the page has already been processed.
+	*/
+	public xhtml(params = '') => {
 
-		if(local_defined('params') && #params >> '-xhtml');
-			local('xhtmlparam'=#params -> find('-xhtml') -> first);
+		if(#params >> '-xhtml') => {
+			local(xhtmlparam = #params -> find('-xhtml') -> first)
 
-			if(#xhtmlparam -> type == 'pair'); // -xhtml=true / -xhtml=false
-				return(boolean(#xhtmlparam -> value));
-			else; // plain -xhtml
-				return(true);
-			/if;
+			if(#xhtmlparam -> type == 'pair') => {// -xhtml = true / -xhtml = false
+				return boolean(#xhtmlparam -> value)
+			else // plain -xhtml
+				return true
+			}
 		//added else to bypass problems with content_body inside ajax called page
 		else
-			return(false)
-		/if;
+			return false
+		}
 
-		local('rawcontent' = web_response->rawContent)
+		local(rawcontent = web_response->rawContent)
 
-		if(var('_knop_data') -> type != 'map');
-			$_knop_data = map;
-		/if;
-		if($_knop_data !>> 'doctype_xhtml');
-			local('doctype' = #rawcontent->substring(1, #rawcontent->find('>')));
+		if(var('_knop_data') -> type != 'map') => {
+			$_knop_data = map
+		}
+		if($_knop_data !>> 'doctype_xhtml') => {
+			local(doctype = #rawcontent->substring(1, #rawcontent->find('>')))
 
-			$_knop_data -> insert('doctype_xhtml' = (#doctype >> '<!DOCTYPE' && #doctype >> 'xhtml'));
-		/if;
-		return($_knop_data -> find('doctype_xhtml'));
+			$_knop_data -> insert('doctype_xhtml' = (#doctype >> '<!DOCTYPE' && #doctype >> 'xhtml'))
+		}
+		return $_knop_data -> find('doctype_xhtml')
 	}
 
-
+	/**!
+	error_lang
+	Returns a reference to the language object used for error codes, to be able to add localized error messages to any Knop type (except knop_lang and knop_base)
+	*/
 	public error_lang() => {
-		local('description'='Returns a reference to the language object used for error codes, to be able to add localized error messages to any Knop type (except knop_lang and knop_base)');
-		return( 'error_lang')
+		return 'error_lang'
 	}
 
-	public error_code() => {
-		local('description'='Either proprietary error code or standard Lasso error code')
-		return(integer(self -> 'error_code'))
-	}
+	/**!
+	error_code
+	Either proprietary error code or standard Lasso error code
+	*/
+	public error_code() => integer(self -> 'error_code')
 
-	public error_msg(error_code::integer=-1) =>{
+	public error_msg(error_code::integer = -1) =>{
 		#error_code < 0 ? #error_code = .error_code
-		local('error_lang_custom' = .error_lang)
-		local('error_lang' = knop_lang(-default='en', -fallback))
+		local(error_lang_custom = .error_lang)
+		local(error_lang = knop_lang(-default = 'en', -fallback))
 
-		local('errorcodes' = map(
+		local(errorcodes = map(
 			0 = 'No error',
 			-1728 = 'No records found', // standard Lasso error code
 
@@ -206,42 +216,42 @@ define knop_base => type {
 			7502 = 'Username or password missing',
 			7503 = 'Client fingerprint has changed'
 
-			));
-		#error_lang -> addlanguage(-language = 'en', -strings = #errorcodes);
+			))
+		#error_lang -> addlanguage(-language = 'en', -strings = #errorcodes)
 		// add any custom error strings
-		iterate(#error_lang_custom -> 'strings', local('custom_language'));
-			if(#error_lang -> 'strings' !>> #custom_language -> name);
+		with custom_language in #error_lang_custom -> 'strings' do {
+			if(#error_lang -> 'strings' !>> #custom_language -> name) => {
 				// add entire language at once
-				#error_lang -> addlanguage(-language=#custom_language -> name, -strings=#custom_language -> value);
-			else;
+				#error_lang -> addlanguage(-language = #custom_language -> name, -strings = #custom_language -> value)
+			else
 				// add one string at a time
-				iterate(#custom_language -> value, local('custom_string'));
-					#error_lang -> insert(-language=#custom_language -> name,
-						-key=#custom_string -> name,
-						-value=#custom_string -> value);
-				/iterate;
-			/if;
-		/iterate;
+				with custom_string in #custom_language -> value do {
+					#error_lang -> insert(-language = #custom_language -> name,
+						-key = #custom_string -> name,
+						-value = #custom_string -> value)
+				}
+			}
+		}
 
-		if(#errorcodes >> #error_code);
+		if(#errorcodes >> #error_code) => {
 			// return error message defined by this tag
-			if(#error_lang -> keys >> #error_code);
+			if(#error_lang -> keys >> #error_code) => {
 
-				return(#error_lang -> getstring(#error_code));
-			else;
-				return(#errorcodes -> find(#error_code));
-			/if;
-		else;
-			if((self -> 'error_msg') != '');
+				return #error_lang -> getstring(#error_code)
+			else
+				return #errorcodes -> find(#error_code)
+			}
+		else
+			if((self -> 'error_msg') != '') => {
 				// return literal error message
-				return((self -> 'error_msg'));
-			else;
+				return (self -> 'error_msg')
+			else
 				// test for error known by lasso
-				error_code = #error_code;
+				error_code = #error_code
 				// return Lasso error message
-				return(error_msg);
-			/if;
-		/if;
+				return error_msg
+			}
+		}
 	}
 
 	public varname() => debug => {
@@ -256,7 +266,7 @@ define knop_base => type {
 				if(#thisvar -> type == .type
 					&& (#thisvar -> 'instance_unique') == .'instance_unique') => {
 					.'instance_varname' = string(#varname)
-					return(.'instance_varname')
+					return .'instance_varname'
 				}
 			}
 
@@ -265,37 +275,37 @@ define knop_base => type {
 	} // END varname
 
 /* removed by Jolle 2011-03-10
-	public trace(html::boolean=false, xhtml::boolean=false) =>{
-		local('description'='Returns the debug trace for a type instance');
+	public trace(html::boolean = false, xhtml::boolean = false) =>{
+		local(description = 'Returns the debug trace for a type instance')
 
-		local('endslash' = (self ->xhtml(params) ? ' /' | ''))
-		local('eol'=( local_defined('html') || #endslash -> size >0 ? ('<br' + #endslash + '>\n') | '\n'));
-		local('trace'= self -> 'debug_trace');
-		self ->'_debug_trace'-> isa('array') ? #trace -> merge(self -> '_debug_trace');
+		local(endslash = (self ->xhtml(params) ? ' /' | ''))
+		local(eol = ( local_defined('html') || #endslash -> size >0 ? ('<br' + #endslash + '>\n') | '\n'))
+		local(trace= self -> 'debug_trace')
+		self ->'_debug_trace'-> isa('array') ? #trace -> merge(self -> '_debug_trace')
 		return(#eol + 'Debug trace for ' +self -> type+' $' +self -> varname+ #eol+#trace->join(#eol)+#eol)
 
 	}
 
 
-	public tagtime(html::boolean=false, xhtml::boolean=false) => {
-		local('description'='Returns the time it took to execute the last executed member tag for a type instance.')
+	public tagtime(html::boolean = false, xhtml::boolean = false) => {
+		local(description = 'Returns the time it took to execute the last executed member tag for a type instance.')
 		// Standard timer code
 		//At beginning of tag code:
-		//local: 'timer'=knop_timer;
+		//local: 'timer' = knop_timer
 
 		//Before the end of tag code (before return):
-		//self -> 'tagtime_tagname'=tag_name;
-		//self -> 'tagtime'=integer(#timer); // cast to integer to trigger onconvert and to "stop timer"
+		//self -> 'tagtime_tagname' = tag_name
+		//self -> 'tagtime' = integer(#timer) // cast to integer to trigger onconvert and to "stop timer"
 
-		local('endslash' = (self ->xhtml(params) ? ' /' | ''));
+		local(endslash = (self ->xhtml(params) ? ' /' | ''))
 
 		(#html || #xhtml) ? return(self -> type+ '->' + self -> 'tagtime_tagname' + ': ' + self -> 'tagtime' + ' ms<br' + #endslash + '>')
 		return(self -> 'tagtime')
 	}
 
-	public tagtime(html::boolean=false, xhtml::boolean=false) => {
-		local('description'='Returns the time it took to execute the last executed member tag for a type instance.')
-		local('endslash' = (self ->xhtml(params) ? ' /' | ''));
+	public tagtime(html::boolean = false, xhtml::boolean = false) => {
+		local(description = 'Returns the time it took to execute the last executed member tag for a type instance.')
+		local(endslash = (self ->xhtml(params) ? ' /' | ''))
 
 		(#html || #xhtml) ? return(self -> type+ '->' + self -> 'tagtime_tagname' + ': ' + self -> 'tagtime' + ' ms<br' + #endslash + '>')
 		return(self -> 'tagtime')
@@ -313,6 +323,6 @@ In dialog between Jolle and Tim 2011-03-10
 
 }
 
-log_critical('loading  knop_base done')
+//log_critical('loading  knop_base done')
 
 ?>

--- a/knop9/knoplibs/knop_cache.lasso
+++ b/knop9/knoplibs/knop_cache.lasso
@@ -30,6 +30,7 @@ define knop_cache => thread {
 	/*
 
 	CHANGE NOTES
+	2012-06-11	JC	Replaced all iterate with query expr. Other minor code changes. Fixed misplaced curly brackets around named signature calls
 	2010-08-04	JC	Minor code cleaning
 	2009-11-25	JC	First experimental version with all functions in place. Still lacks debug and timer functions. Introduces the new thread object knop_cache instead of global vars
 
@@ -40,24 +41,24 @@ define knop_cache => thread {
 	data private caches = map
 	data public purged
 
-	public add(name::string, content::any, expires::integer = 600) => .caches -> insert(#name = map('content' = #content, 'timestamp' = date, 'expires' = (date + duration( -second = #expires))))
+	public add(name::string, content::any, expires::integer = 600) => .'caches' -> insert(#name = map('content' = #content, 'timestamp' = date, 'expires' = (date + duration( -second = #expires))))
 
-	public get(name::string) => .caches -> find(#name)
+	public get(name::string) => .'caches' -> find(#name)
 
-	public getall => .caches
+	public getall => .'caches'
 
-	public remove(name::string) => {.caches -> remove(#name)}
+	public remove(name::string) => {.'caches' -> remove(#name)}
 
-	public clear => {.caches = map}
+	public clear => {.'caches' = map}
 
 	public active_tick() => {
-		iterate(.caches, local(i));
-			if(#i -> value -> find('expires') < date);
-				.caches -> remove(#i -> name);
-			/if;
-		/iterate;
-		.purged = date;
-		return 600;
+		with i in .'caches' -> eachPair do => {
+			if(#i -> value -> find('expires') < date) => {
+				.'caches' -> remove(#i -> name)
+			}
+		}
+		.purged = date
+		return 600
 	}
 
 
@@ -81,34 +82,34 @@ define knop_cachestore(
 ) => {
 //log_critical('knop_cachestore  called')
 
-	local('data' = map);
-	#expires < 0 ? #expires = 600; // default seconds
+	local(data = map)
+	#expires < 0 ? #expires = 600 // default seconds
 	// store all page vars of the specified type
-	local(loopvalue = string);
+	local(loopvalue = string)
 	// store all page vars of the specified type
-	iterate(var_keys);
-		#loopvalue = loop_value -> asstring;
-		if(var(#loopvalue) -> isa(#type));
-			#data -> insert(#loopvalue = var( #loopvalue));
-		/if;
-	/iterate;
-	if(#session -> size > 0);
-		local('cache_name' = '_knop_cache_' + #name);
-		session_addvar(-name = #session, #cache_name);
-		!(var(#cache_name) -> isa('map')) ? var(#cache_name = map);
+	with keytmp in var_keys do => {
+		#loopvalue = string(#keytmp)
+		if(var(#loopvalue) -> isa(#type)) => {
+			#data -> insert(#loopvalue = var( #loopvalue))
+		}
+	}
+	if(#session -> size > 0) => {
+		local(cache_name = '_knop_cache_' + #name)
+		session_addvar(-name = #session, #cache_name)
+		!(var(#cache_name) -> isa(::map)) ? var(#cache_name = map)
 		var( #cache_name) -> insert(#type = map(
 			'content' = #data,
 			'timestamp' = date,
-			'expires' = (date + duration( -second = #expires))));
+			'expires' = (date + duration( -second = #expires))))
 	else;
 
-		local('cache_name' = 'knop_' + #name + '_' + server_name + response_localpath);
-		#cache_name -> removetrailing(response_filepath);
-		#cache_name -> replace('/','');
-		#cache_name += '_' + #type;
-		knop_cache -> add(#cache_name, #data, #expires);
+		local('cache_name' = 'knop_' + #name + '_' + server_name + response_localpath)
+		#cache_name -> removetrailing(response_filepath)
+		#cache_name -> replace('/','')
+		#cache_name += '_' + #type
+		knop_cache -> add(#cache_name, #data, #expires)
 
-	/if;
+	}
 
 }
 
@@ -117,7 +118,7 @@ define knop_cachestore(
 	-expires::integer = -1,
 	-session::string = '',
 	-name::string = ''
-) => {knop_cachestore(#type, #expires,#session,#name)}
+) => knop_cachestore(#type, #expires,#session,#name)
 
 /**
 knop_cachefetch
@@ -136,38 +137,39 @@ define knop_cachefetch(
 	maxage::date = date('1970-01-01')
 ) => {
 
-	local('data' = null);
-	if(#session -> size > 0);
-		//fail_if(session_id( -name=#session) -> size == 0, -1, 'Cachefetch with -session requires that the specified session is started');
-		local('cache_name' = '_knop_cache_' + #name);
-		if(var(#cache_name) -> isa('map')
+	local(data = null)
+	if(#session -> size > 0) => {
+		//fail_if(session_id( -name=#session) -> size == 0, -1, 'Cachefetch with -session requires that the specified session is started')
+		local(cache_name = '_knop_cache_' + #name)
+		if(var(#cache_name) -> isa(::map)
 			&& var(#cache_name) >> #type
 			&& var(#cache_name) -> find(#type) -> find('expires') > date
-			&& var(#cache_name) -> find(#type) -> find('timestamp') > #maxage);
+			&& var(#cache_name) -> find(#type) -> find('timestamp') > #maxage) => {
 			// cached data not too old
-			#data = var(#cache_name) -> find(#type) -> find('content');
-		/if;
-	else;
-		local('cache_name' = 'knop_' + #name + '_' + server_name + response_localpath);
-		#cache_name -> removetrailing(response_filepath);
-		#cache_name -> replace('/','');
-		#cache_name += '_' + #type;
-		local(content = knop_cache -> get(#cache_name));
-		if(#content -> isa('map')
+			#data = var(#cache_name) -> find(#type) -> find('content')
+		}
+	else
+		local('cache_name' = 'knop_' + #name + '_' + server_name + response_localpath)
+		#cache_name -> removetrailing(response_filepath)
+		#cache_name -> replace('/','')
+		#cache_name += '_' + #type
+		local(content = knop_cache -> get(#cache_name))
+		if(#content -> isa(::map)
 			&& #content -> find('expires') > date
-			&& #content -> find('timestamp') > #maxage);
+			&& #content -> find('timestamp') > #maxage) => {
 			// cached data not too old
 			#data = #content -> find('content');
-		/if;
-	/if;
-	if(#data -> isa('map'));
-		iterate(#data, local('i'));
-			var((#i -> name) = #i -> value);
-		/iterate;
-		return true;
-	else;
-		return false;
-	/if;
+		}
+	}
+	if(#data -> isa(::map)) => {
+
+		with i in #data -> eachpair do => {
+			var((#i -> name) = #i -> value)
+		}
+		return true
+	else
+		return false
+	}
 
 }
 
@@ -176,7 +178,7 @@ define knop_cachefetch(
 	-session::string = '',
 	-name::string = '',
 	-maxage::date = date('1970-01-01')
-) => {return knop_cachefetch(#type, #session, #name, #maxage)}
+) => knop_cachefetch(#type, #session, #name, #maxage)
 
 /**
 knop_cachedelete
@@ -191,21 +193,21 @@ define knop_cachedelete(
 	session::string = '',
 	name::string = ''
 ) => {
-	if(#session -> size > 0);
+	if(#session -> size > 0) => {
 		//fail_if(session_id( -name=#session) -> size == 0, -1, 'Cachestore with -session requires that the specified session is started');
-		local('cache_name' = '_knop_cache_' + #name);
-		session_addvar(-name = #session, #cache_name);
-		!(var(#cache_name) -> isa('map')) ? var(#cache_name = map);
-		var(#cache_name) -> remove(#type);
-	else;
-		local('cache_name' = 'knop_' + #name + '_' + server_name + response_localpath);
-		#cache_name -> removetrailing(response_filepath);
-		#cache_name -> replace('/','');
-		#cache_name += '_' + #type;
+		local(cache_name = '_knop_cache_' + #name)
+		session_addvar(-name = #session, #cache_name)
+		!(var(#cache_name) -> isa(::map)) ? var(#cache_name = map)
+		var(#cache_name) -> remove(#type)
+	else
+		local(cache_name = 'knop_' + #name + '_' + server_name + response_localpath)
+		#cache_name -> removetrailing(response_filepath)
+		#cache_name -> replace('/','')
+		#cache_name += '_' + #type
 
-		knop_cache -> remove(#cache_name);
+		knop_cache -> remove(#cache_name)
 
-	/if;
+	}
 
 }
 
@@ -213,7 +215,8 @@ define knop_cachedelete(
 	-type::string,
 	-session::string = '',
 	-name::string = ''
-) => {knop_cachedelete(#type, #session, #name)}
+) => knop_cachedelete(#type, #session, #name)
 
+//log_critical('loading knop_cache done')
 
 ?>

--- a/knop9/knoplibs/knop_form.lasso
+++ b/knop9/knoplibs/knop_form.lasso
@@ -1,8 +1,18 @@
 <?Lasso
-log_critical('loading knop_form from LassoApp')
+log_critical('loading knop_form')
 
 define knop_form => type {
 /*
+
+	2013-03-12	JC	Changed encode_html(#requiredmarker) to #requiredmarker
+	2013-03-12	JC	Changed renderform to use #labelstart##labelend# instead of #label#. This to enable #required# to be part of the <label>text</label> code
+	2013-03-12	JC	Fixes in renderhtml that contained tracking code no longer needed. Also changed replace #label# calls that should have been #required#
+	2013-01-21	JC	Changed remaining isa('xxxx') to isa(::xxxx)
+	2012-10-30	JC	Fixed bug preventing hint on input type text field to work properly
+	2012-10-20	JC	Expanded support for input type text to include 'text', 'url', 'email', 'number', 'tel'
+	2012-10-11	JC	Changing errorclass so that it defaults to "error"
+	2012-10-11	JC	Added support for helpblock and error class marking where requested
+	2012-09-21	JC	Added support for bootstrap markup of checkbox. New param -bootstrap in render_form
 	2012-07-02	JC	Fixed erroneous handling of addlock and clearlocks
 	2012-06-10	JC	Changed all iterate to query expr. Changed all += to append. Set br to br /
 	2012-06-07	JC	Tweaks to make knop_form -> process work
@@ -33,7 +43,7 @@ define knop_form => type {
 */
 	parent knop_base
 
-	data public version = '2012-07-02'
+	data public version = '2013-03-12'
 
 	// instance variables
 	data public fields::array = array
@@ -90,7 +100,7 @@ define knop_form => type {
 	data public error_lang = knop_lang(-default = 'en', -fallback)
 	data public errors = null
 	//config vars
-	data public validfieldtypes::map = map('text' = '', 'password' = '', 'checkbox' = '', 'radio' = '', 'textarea' = '', 'select' = '', 'file' = '', 'search' = '', 'submit' = '', 'reset' = '', 'image' = '', 'hidden' = '', 'fieldset' = '', 'legend' = '', 'html' = '')
+	data public validfieldtypes::map = map('text' = '', 'password' = '', 'checkbox' = '', 'radio' = '', 'textarea' = '', 'select' = '', 'file' = '', 'search' = '', 'submit' = '', 'reset' = '', 'image' = '', 'hidden' = '', 'fieldset' = '', 'legend' = '', 'html' = '', 'url' = string, 'email' = string, 'number' = string, 'tel' = string)
 	//special types
 	data public exceptionfieldtypes::map = map('file' = '', 'submit' = '', 'reset' = '', 'image' = '', 'addbutton' = '', 'savebutton' = '', 'searchbutton' = '', 'deletebutton' = '', 'cancelbutton' = '', 'fieldset' = '', 'legend' = '', 'html' = '')
 
@@ -116,7 +126,7 @@ define knop_form => type {
 			-buttontemplate (optional string) html template for buttons, defaults to #field# but uses -template if specified\n\
 			-required (optional string) character(s) to display for required fields (used for #required#), defaults to *\n\
 			-class (optional string) css class name that will be used for the form element, default none\n\
-			-errorclass (optional string) css class name that will be used for the label to highlight input errors, if not defined style="color: red" will be used\n\
+			-errorclass (optional string) css class name that will be used for the label to highlight input errors, default error\n\
 			-unsavedmarker (optional string) id for html element that should be used to indicate when the form becomes dirty. \n\
 			-unsavedmarkerclass (optional string) class name to use for the html element. Defaults to "unsaved". \n\
 			-unsavedwarning (optional string)\n\
@@ -124,7 +134,7 @@ define knop_form => type {
 			-noscript (optional flag) if specified, don\'t inject any javascript in the form. This will disable all client side functionality such as hints, focus and unsaved warnings. \n\
 			-database (optional database) Optional database object that the form object will interact with
 **/
-	public oncreate(formaction = null, method = '', name = '', id = '', raw = '',actionpath = '', fieldset::boolean = false, legend = '', entersubmitblock = false, noautoparams = false, template::string = '', buttontemplate::string = '', required::string = '*', class::string = '', errorclass::string = '', unsavedmarker::string = '', unsavedmarkerclass::string = 'unsaved', unsavedwarning::string = '', keyparamname::string = '-keyvalue', noscript = true, database::any = '')
+	public oncreate(formaction = null, method = '', name = '', id = '', raw = '',actionpath = '', fieldset::boolean = false, legend = '', entersubmitblock = false, noautoparams = false, template::string = '', buttontemplate::string = '', required::string = '*', class::string = '', errorclass::string = 'error', unsavedmarker::string = '', unsavedmarkerclass::string = 'unsaved', unsavedwarning::string = '', keyparamname::string = '-keyvalue', noscript = true, database::any = '')
 		=> {
 //		debug => {
 
@@ -137,7 +147,7 @@ define knop_form => type {
 		.'buttontemplate' = #buttontemplate
 		.'required' = #required
 		.'class' = #class
-		.'errorclass' = #errorclass
+		.errorclass = #errorclass
 		.'unsavedmarker' = #unsavedmarker
 		.'unsavedmarkerclass' = #unsavedmarkerclass
 		.'unsavedwarning' = #unsavedwarning
@@ -165,7 +175,7 @@ define knop_form => type {
 // 	} // end debug
 	} // END oncreate
 
-	public oncreate(-formaction = null, -method = '', -name = '', -id = '', -raw = '', -actionpath = '', -fieldset::boolean = false, -legend = '', -entersubmitblock = false, -noautoparams = false, -template::string = '', -buttontemplate::string = '', -required::string = '*', -class::string = '', -errorclass::string = '', -unsavedmarker::string = '', -unsavedmarkerclass::string = 'unsaved', -unsavedwarning::string = '', -keyparamname::string = '-keyvalue', -noscript = true, -database::any = '') => .oncreate(#formaction, #method, #name, #id, #raw, #actionpath, #fieldset, #legend, #entersubmitblock, #noautoparams, #template, #buttontemplate, #required, #class, #errorclass, #unsavedmarker, #unsavedmarkerclass, #unsavedwarning, #keyparamname, #noscript, #database)
+	public oncreate(-formaction = null, -method = '', -name = '', -id = '', -raw = '', -actionpath = '', -fieldset::boolean = false, -legend = '', -entersubmitblock = false, -noautoparams = false, -template::string = '', -buttontemplate::string = '', -required::string = '*', -class::string = '', -errorclass::string = 'error', -unsavedmarker::string = '', -unsavedmarkerclass::string = 'unsaved', -unsavedwarning::string = '', -keyparamname::string = '-keyvalue', -noscript = true, -database::any = '') => .oncreate(#formaction, #method, #name, #id, #raw, #actionpath, #fieldset, #legend, #entersubmitblock, #noautoparams, #template, #buttontemplate, #required, #class, #errorclass, #unsavedmarker, #unsavedmarkerclass, #unsavedwarning, #keyparamname, #noscript, #database)
 
 /**!
 onconvert
@@ -207,9 +217,9 @@ Shortcut to getvalue
 	Inserts a form element in the form. \n\
 
 			Parameters:\n\
-			-type (required) Supported types are listed in form -> \'validfieldtypes\'. Also custom field types addbuton, savebutton or deletebutton are supported (translated to submit buttons with predefined names). \
+			-type (required) Supported types are listed in form -> \'validfieldtypes\'. Also custom field types addbutton, savebutton or deletebutton are supported (translated to submit buttons with predefined names). \
 			For the field types html, fieldset and legend use -value to specify the data to display for these fields. A legend field automatically creates a fieldset (closes any previously open fieldsets). Use fieldset with -value = false to close a fieldset without opening a new one. \n\
-			-name (optional) Required for all input types except addbuton, savebutton, deletebutton, fieldset, legend and html\n\
+			-name (optional) Required for all input types except addbutton, savebutton, deletebutton, fieldset, legend and html\n\
 			-id (optional) id for the html object, will be autogenerated if not specified\n\
 			-dbfield (optional) Corresponding database field name (name is used if dbfield is not specified), or null/emtpy string if ignore this field for database\n\
 			-value (optional) Initial value for the field\n\
@@ -244,13 +254,14 @@ Shortcut to getvalue
 		hint = '',
 		options = '',
 		default = '',
-		size = '',
-		maxlength = '',
-		rows = '',
-		cols = '',
+		size = -1,
+		maxlength = -1,
+		rows = -1,
+		cols = -1,
 		class = '',
 		labelclass = '',
 		raw = '',
+		helpblock = '',
 		confirmmessage = '',
 		validate = '',
 		filter = '',
@@ -329,18 +340,19 @@ Shortcut to getvalue
 		#field -> insert('type' = #_type)
 		#field -> insert('name' = #_name)
 
-		#field -> insert('id' = #id -> ascopy)
-		#field -> insert('hint' = #hint -> ascopy)
-		#field -> insert('default' = #default -> ascopy)
-		#field -> insert('label' = #label -> ascopy)
-		#field -> insert('size' = #size -> ascopy)
-		#field -> insert('maxlength' = #maxlength -> ascopy)
-		#field -> insert('rows' = #rows -> ascopy)
-		#field -> insert('cols' = #cols -> ascopy)
-		#field -> insert('class' = #class -> ascopy)
-		#field -> insert('labelclass' = #labelclass -> ascopy)
-		#field -> insert('raw' = #raw -> ascopy)
-		#field -> insert('confirmmessage' = #confirmmessage -> ascopy)
+		#id -> size > 0 ? #field -> insert('id' = #id -> ascopy)
+		#hint -> size > 0 ? #field -> insert('hint' = #hint -> ascopy)
+		#default -> size > 0 ? #field -> insert('default' = #default -> ascopy)
+		#label -> size > 0 ? #field -> insert('label' = #label -> ascopy)
+		#size > 0 ? #field -> insert('size' = #size -> ascopy)
+		#maxlength > 0 ? #field -> insert('maxlength' = #maxlength -> ascopy)
+		#rows > 0 ? #field -> insert('rows' = #rows -> ascopy)
+		#cols > 0 ? #field -> insert('cols' = #cols -> ascopy)
+		#class -> size > 0 ? #field -> insert('class' = #class -> ascopy)
+		#labelclass -> size > 0 ? #field -> insert('labelclass' = #labelclass -> ascopy)
+		#raw -> size > 0 ? #field -> insert('raw' = #raw -> ascopy)
+		#helpblock -> size > 0 ? #field -> insert('helpblock' = #helpblock -> ascopy)
+		#confirmmessage -> size > 0 ? #field -> insert('confirmmessage' = #confirmmessage -> ascopy)
 		#field -> insert('originaltype' = #originaltype -> ascopy)
 
 		#field -> insert('dbfield' = ( #dbfield != NULL ? #dbfield -> ascopy | #_name -> ascopy ) )
@@ -357,9 +369,9 @@ Shortcut to getvalue
 // 	} // end debug
 	}
 
-	public addfield(-type, -name = '', -label = '', -value = '', -id = '', -dbfield = NULL, -hint = '', -options = '', -multiple = false, -linebreak = false, -default = '', -size::integer = -1, -maxlength::integer = -1, -rows::integer = -1, -cols::integer = -1, -focus = false, -class = '', -labelclass = '', -disabled = false, -raw = '', -confirmmessage = '', -required = false, -validate = '', -filter = '', -nowarning = false, -op::string = 'bw', -logical_op::string = string, -after = '') => {
+	public addfield(-type, -name = '', -label = '', -value = '', -id = '', -dbfield = NULL, -hint = '', -options = '', -multiple = false, -linebreak = false, -default = '', -size::integer = -1, -maxlength::integer = -1, -rows::integer = -1, -cols::integer = -1, -focus = false, -class = '', -labelclass = '', -disabled = false, -raw = '', -helpblock = '', -confirmmessage = '', -required = false, -validate = '', -filter = '', -nowarning = false, -op::string = 'bw', -logical_op::string = string, -after = '') => {
 
-	.addfield(#type, #name, #label, #value, #id, #dbfield, #hint, #options, #default, #size, #maxlength, #rows, #cols, #class, #labelclass, #raw, #confirmmessage, #validate, #filter, #after, #required, #nowarning, #op, #logical_op, #multiple, #linebreak, #focus, #disabled)
+	.addfield(#type, #name, #label, #value, #id, #dbfield, #hint, #options, #default, #size, #maxlength, #rows, #cols, #class, #labelclass, #raw, #helpblock, #confirmmessage, #validate, #filter, #after, #required, #nowarning, #op, #logical_op, #multiple, #linebreak, #focus, #disabled)
 	}
 
 /*
@@ -560,9 +572,9 @@ Overwrites all field values with values from either database, action_params or e
 						// load field values from explicit -params using dbfield names
 						if(#_params >> #fieldpair -> value -> find('dbfield') && #fieldpair -> value -> find('dbfield') != '') => {
 
-							if(#_params -> isa('map')) => {
+							if(#_params -> isa(::map)) => {
 								#fieldpair -> value -> insert('value' = #_params -> find(#fieldpair -> value -> find('dbfield')) -> asCopy )
-							else(#_params -> isa('array'))
+							else(#_params -> isa(::array))
 								#fieldpair -> value -> insert('value' = #_params -> find(#fieldpair -> value -> find('dbfield')) -> first -> value -> asCopy)
 							}
 						}
@@ -594,7 +606,7 @@ Overwrites all field values with values from either database, action_params or e
 					}
 				}
 				// apply filtering of field value (do this for all instances of the same field name, so outside of the #fieldnames_done check)
-				if(#fieldpair -> value -> find('filter') -> isa('tag')) => {
+				if(#fieldpair -> value -> find('filter') -> isa(::tag)) => {
 					#fieldpair -> value -> insert('value'= #fieldpair -> value -> find('filter') -> run(-params = #fieldpair -> value -> find('value')))
 				}
 			}
@@ -716,7 +728,7 @@ Performs validation and fills a transient array with field names that have input
 					if(#fieldvalue -> value -> find('required') && #fieldvalue -> value -> find('value') == '') => {
 						.'errors' -> insert(#fieldvalue-> value -> find('name') )
 					}
-					if(#fieldvalue -> value -> find('validate') -> isa('tag')) => {
+					if(#fieldvalue -> value -> find('validate') -> isa(::tag)) => {
 						// perform validation expression on the field value
 						local(result = #fieldvalue -> value -> find('validate') -> run(-params = #fieldvalue -> value -> find('value')))
 						if(#result === true || #result === 0) => {
@@ -1112,7 +1124,7 @@ Automatically handles a form submission and handles add, update, or delete.
 
 // 	} // end debug
 	}
-       
+
 /**!
 	Defines a html template for the form. \n\
 			Parameters:\n\
@@ -1121,7 +1133,7 @@ Automatically handles a form submission and handles add, update, or delete.
 			-required (optional string) character(s) to display for required fields (used for #required#), defaults to *\n\
 			-legend (optional string) legend for the entire form - if specified, a fieldset will also be wrapped around the form\n\
 			-class (optional string) css class name that will be used for the form element, default none\n\
-			-errorclass (optional string) css class name that will be used for the label to highlight input errors, if not defined style="color: red" will be used\n\
+			-errorclass (optional string) css class name that will be used for the label to highlight input errors, default error\n\
 			-unsavedmarker (optional string) \n\
 			-unsavedmarkerclass (optional string) \n\
 			-unsavedwarning (optional string)
@@ -1299,8 +1311,17 @@ Outputs HTML for the form fields, a specific field, a range of fields or all fie
 			-end (optional) Only render the ending </form> tag\n\
 			-xhtml (optional flag) XHTML valid output
 **/
-	public renderform(name::string = '', from = 0, to = 0, type = '', excludetype = '', legend::string = '', xhtml::boolean = false, onlyformcontent::boolean = false ) => {
-// debug => {
+	public renderform(
+		name::string = '',
+		from = 0,
+		to = 0,
+		type = '',
+		excludetype = '',
+		legend::string = '',
+		xhtml::boolean = false,
+		onlyformcontent::boolean = false,
+		bootstrap::boolean = false
+	) => debug => {
 /*name::string = '', 	// field name
 		from = 1, 	// number index or field name
 		to = 0, 		// number index or field name
@@ -1338,6 +1359,7 @@ Outputs HTML for the form fields, a specific field, a range of fields or all fie
 		local(_from = #from -> ascopy)
 		local(_to = #to -> ascopy)
 		local(_type = #type -> ascopy)
+		local(linebreak = false)
 
 		local(endslash = (.xhtml(params) ? ' /' | ''))
 
@@ -1354,7 +1376,7 @@ Outputs HTML for the form fields, a specific field, a range of fields or all fie
 			#_to = #name -> ascopy
 		}
 
-		(#_to -> isa('string') && #_to -> size == 0) || (#_to -> isa('integer') && #_to == 0) ? #_to = .'fields' -> size
+		(#_to -> isa(::string) && #_to -> size == 0) || (#_to -> isa(::integer) && #_to == 0) ? #_to = .'fields' -> size
 		#_type == '' ? #_type = .'validfieldtypes'
 		#excludetype == '' ? #excludetype = map
 		#_type -> isa(::string) ? #_type = map(#_type)
@@ -1378,19 +1400,21 @@ Outputs HTML for the form fields, a specific field, a range of fields or all fie
 		// sanity check
 		#_from > #_to ? #_to = #_from
 
-		local(template = ( .'template' != '' ? .'template' | '#label# #field##required#<br />\n' ) )
+		local(template = ( .template != '' ? .template | '#label# #field##required#<br />\n' ) )
+
+		#template -> replace('#label#', '#labelstart##labelend#')
+
 
 		//local('buttontemplate'= ( .'buttontemplate' != '' ? .'buttontemplate' | (.'template' != '' ? .'template' | '#field#\n' )))
-		if(.'buttontemplate' -> size > 0) => {
-			local('buttontemplate'= .'buttontemplate')
+		if(.buttontemplate -> size > 0) => {
+			local(buttontemplate = .'buttontemplate')
 		else(.'template' -> size > 0)
-			local('buttontemplate'= .'template')
+			local(buttontemplate = .'template')
 		else
-			local('buttontemplate'= '#field#\n')
+			local(buttontemplate = '#field#\n')
 		}
 		local(requiredmarker = .'required')
 		local(defaultclass = ( .'class' != '' ? .'class' | ''))
-		local(errorclass = ( .'errorclass' != '' ? (' class="' + .'errorclass' + '"') | ' style="color: red;"'))
 		if(#legend -> size > 0) => {
 			.'render_fieldset2_open' = true
 			#output -> append('<fieldset>\n' + '<legend>' + #legend + '</legend>\n')
@@ -1440,7 +1464,7 @@ Outputs HTML for the form fields, a specific field, a range of fields or all fie
 				else
 					#renderrow = #template -> asCopy
 				}
-				if(#onefield -> find('id') != '') => {
+				if(#onefield -> find('id') -> size) => {
 					local(id = #onefield -> find('id'))
 				else
 					local(id = (.'formid' + '_' + #onefield ->find('name') + loop_count))
@@ -1455,18 +1479,32 @@ Outputs HTML for the form fields, a specific field, a range of fields or all fie
 				//	#renderrow -> replace('#label#', '')
 				//else:
 				if(.'errors'-> isa(::array) && .'errors' >> #onefield -> find('name')) => {
-					#renderrow -> replace('#label#',
-						('<label for="' + #id + '" id="' + #id + '_label" ' + #errorclass + '>' + #onefield -> find('label') + '</label>'))
+					#renderrow -> replace('#labelstart#',
+						('<label for="' + #id + '" id="' + #id + '_label" class="' + .errorclass + '">' + #onefield -> find('label')))
+					#renderrow -> replace('#labelend#',
+						('</label>'))
+					#renderrow ->replace('#errorclass#', .errorclass)
 					if(#focusfield == '') => {
 						#focusfield = #id
 					}
 				else
-					#renderrow ->replace('#label#', ('<label for="' + #id + '" id="' + #id + '_label">' + #onefield -> find('label') + '</label>'))
+					#renderrow ->replace('#labelstart#', ('<label for="' + #id + '" id="' + #id + '_label">' + #onefield -> find('label')))
+					#renderrow ->replace('#labelend#', ('</label>'))
+					#renderrow ->replace('#errorclass#', '')
 				}
+
+				if(#onefield -> find('helpblock') -> size) => {
+					#renderrow -> replace('#helpblock#', #onefield -> find('helpblock'))
+				else
+					#renderrow -> replace('#helpblock#', '')
+				}
+
+				// helps identifying layout blocks related to this field
+				#renderrow -> replace('#id#', #id)
 
 				// set markers for required fields
 				if(#onefield -> find('required') && .'exceptionfieldtypes' !>> #fieldtype) => {
-					#renderrow -> replace('#required#', encode_html(#requiredmarker))
+					#renderrow -> replace('#required#', #requiredmarker)
 				else
 					#renderrow -> replace('#required#', '')
 				}
@@ -1486,7 +1524,8 @@ Outputs HTML for the form fields, a specific field, a range of fields or all fie
 					case('html')
 
 						#renderrow = #template -> ascopy
-						#renderrow -> replace('#label#', '')
+						#renderrow -> replace('#labelstart#', '')
+						#renderrow -> replace('#labelend#', '')
 						#renderrow -> replace('#required#', '')
 						#renderfield = (#fieldvalue + '\n')
 					case('legend')
@@ -1522,15 +1561,17 @@ Outputs HTML for the form fields, a specific field, a range of fields or all fie
 							+ ' value="' + encode_html(#fieldvalue) + '"' + #endslash + '>')
 						#renderrow = ''
 						#output -> append((#renderfield + '\n'))
-					case('text')
-						#renderfield -> append('<input type="text"'
+					case('text', 'url', 'email', 'number', 'tel')
+						#renderfield -> append('<input type="' + #fieldtype + '"'
 							+ #renderfield_base
 							+ ' value="' + encode_html(#fieldvalue) + '"'
 							+ (#onefield >> 'size' 	? (' size="' + #onefield ->find('size') + '"' ))
 							+ (#onefield >> 'maxlength' ? (' maxlength="' + #onefield ->find('maxlength') + '"' )))
-						if(!.'noscript' && #onefield ->find('hint') != '') => {
+						if(!.'noscript' && #onefield ->find('hint') -> size > 0) => {
 							#renderfield -> append(' onfocus="clearHint(this)" onblur="setHint(this, \''+#onefield ->find('hint')+'\')"')
 							#usehint ->insert(#onefield -> find('name') = #id)
+						else(#onefield ->find('hint') -> size > 0)
+							#renderfield -> append(' placeholder="' + encode_html(#onefield ->find('hint')) + '"')
 						}
 						if(!.'noscript' && !#nowarning) => {
 							#renderfield -> append(' onkeydown="dirtyvalue(this)" onkeyup="makedirty(this)"')
@@ -1541,7 +1582,7 @@ Outputs HTML for the form fields, a specific field, a range of fields or all fie
 							+ #renderfield_base
 							+ ' value="' + encode_html(#fieldvalue) + '"'
 							+ (#onefield >> 'size' 	? (' size="' + #onefield ->find('size') + '"' )))
-						if(#onefield ->find('hint') != '') => {
+						if(#onefield ->find('hint') -> size > 0) => {
 							#renderfield -> append(' placeholder="' + encode_html(#onefield ->find('hint')) + '"')
 						}
 						if(!.'noscript' && !#nowarning) => {
@@ -1571,78 +1612,142 @@ Outputs HTML for the form fields, a specific field, a range of fields or all fie
 						}
 						#renderfield -> append('>' + encode_html(#fieldvalue) + '</textarea>')
 					case('checkbox')
-						local(optioncount = integer)
-						#renderfield -> append('<div class="inputgroup'
-							+ (#onefield -> find('class') -> size > 0 ?  ' ' + (#onefield -> find('class'))
-							| (#defaultclass != '' ? ' ' + #defaultclass) )
-							+ '" id="' + #id + '">\n')
+						#linebreak = #onefield -> find('linebreak')
+						if(#bootstrap) => {
+							local(optioncount = integer)
+							#renderfield -> append('<div class="inputgroup'
+								+ (#onefield -> find('class') -> size > 0 ?  ' ' + (#onefield -> find('class'))
+								| (#defaultclass != '' ? ' ' + #defaultclass) )
+								+ '" id="' + #id + '">\n')
 
-						with optionitem in #options do => {
+							with optionitem in #options do => {
 
-							#optioncount += 1
-							#renderfield -> append( (#optioncount > 1 && #onefield -> find('linebreak')) ? ('<br />') + '\n')
-							if(#optionitem -> name == '-optgroup') => {
-								#renderfield -> append((!#onefield -> find('linebreak') && #optioncount > 1) ? ('\n<br />'))
-								if(#optionitem -> value != '-optgroup') => {
-									#renderfield -> append(#optionitem -> value
-										+ (!#onefield -> find('linebreak') ? ('<br />\n')))
+								#optioncount += 1
+//								#renderfield -> append( (#optioncount > 1 && #linebreak) ? ('<br />') + '\n')
+								if(#optionitem -> name == '-optgroup') => {
+									#renderfield -> append((!#linebreak && #optioncount > 1) ? ('\n<br />'))
+									if(#optionitem -> value != '-optgroup') => {
+										#renderfield -> append(#optionitem -> value
+											+ (!#linebreak ? ('<br />\n')))
+									}
+								else
+									#renderfield -> append('<label class="checkbox ' + (#linebreak ? ' inline') + '"><input type="checkbox"'
+										+ string_replaceregexp(#renderfield_base, -find = 'id="(.+?)"', -replace = ('id="\\1_' + #optioncount + '"'))
+										+ ' value="' + encode_html(#optionitem -> name) + '"')
+									if(#optionitem -> name != '' && #fieldvalue_array >> #optionitem -> name) => {
+										#renderfield -> append(' checked="checked"')
+									}
+									#renderfield -> append(#endslash + '> ' + #optionitem -> value + '</label>\n')
 								}
-							else
-								#renderfield -> append('<span><input type="checkbox"'
-									+ string_replaceregexp(#renderfield_base, -find = 'id="(.+?)"', -replace = ('id="\\1_' + #optioncount + '"'))
-									+ ' value="' + encode_html(#optionitem -> name) + '"')
-								if(#optionitem -> name != '' && #fieldvalue_array >> #optionitem -> name) => {
-									#renderfield -> append(' checked="checked"')
-								}
-								if(!.'noscript' && !#nowarning) => {
-									#renderfield -> append(' onclick="makedirty();"')
-								}
-								#renderfield -> append(#endslash + '> <label for="' + #id + '_' + #optioncount
-									+ '" id="' + #id + '_' + #optioncount + '_label"')
-								if(.'noscript' && !#nowarning) => {
-									#renderfield -> append(' onclick="makedirty();"')
-								}
-								#renderfield -> append('>' + #optionitem -> value + '</label></span>')
 							}
+							#renderfield -> append('</div>\n')
+						else
+							local(optioncount = integer)
+							#renderfield -> append('<div class="inputgroup'
+								+ (#onefield -> find('class') -> size > 0 ?  ' ' + (#onefield -> find('class'))
+								| (#defaultclass != '' ? ' ' + #defaultclass) )
+								+ '" id="' + #id + '">\n')
+
+							with optionitem in #options do => {
+
+								#optioncount += 1
+								#renderfield -> append( (#optioncount > 1 && #linebreak) ? ('<br />') + '\n')
+								if(#optionitem -> name == '-optgroup') => {
+									#renderfield -> append((!#linebreak && #optioncount > 1) ? ('\n<br />'))
+									if(#optionitem -> value != '-optgroup') => {
+										#renderfield -> append(#optionitem -> value
+											+ (!#linebreak ? ('<br />\n')))
+									}
+								else
+									#renderfield -> append('<span><input type="checkbox"'
+										+ string_replaceregexp(#renderfield_base, -find = 'id="(.+?)"', -replace = ('id="\\1_' + #optioncount + '"'))
+										+ ' value="' + encode_html(#optionitem -> name) + '"')
+									if(#optionitem -> name != '' && #fieldvalue_array >> #optionitem -> name) => {
+										#renderfield -> append(' checked="checked"')
+									}
+									if(!.'noscript' && !#nowarning) => {
+										#renderfield -> append(' onclick="makedirty();"')
+									}
+									#renderfield -> append(#endslash + '> <label for="' + #id + '_' + #optioncount
+										+ '" id="' + #id + '_' + #optioncount + '_label"')
+									if(.'noscript' && !#nowarning) => {
+										#renderfield -> append(' onclick="makedirty();"')
+									}
+									#renderfield -> append('>' + #optionitem -> value + '</label></span>')
+								}
+							}
+							#renderfield -> append('</div>\n')
 						}
-						#renderfield -> append('</div>\n')
+
 
 					case('radio')
-						local(optioncount = integer)
-						#renderfield -> append('<div class="inputgroup'
-							+ (#onefield -> find('class') -> size > 0 ?  ' ' + (#onefield -> find('class'))
-							| (#defaultclass != '' ? ' ' + #defaultclass) )
-							+ '" id="' + #id + '">\n')
+						if(#bootstrap) => {
+							local(optioncount = integer)
+							#renderfield -> append('<div class="inputgroup'
+								+ (#onefield -> find('class') -> size > 0 ?  ' ' + (#onefield -> find('class'))
+								| (#defaultclass != '' ? ' ' + #defaultclass) )
+								+ '" id="' + #id + '">\n')
 
-						with optionitem in #options do => {
+							with optionitem in #options do => {
 
-							#optioncount += 1
-							#renderfield -> append(((#optioncount > 1 && #onefield -> find('linebreak')) ? ('<br />') )+ '\n')
-							if(#optionitem -> name == '-optgroup') => {
-								#renderfield -> append((!#onefield -> find('linebreak') && #optioncount > 1) ? ('\n<br />'))
-								if(#optionitem -> value != '-optgroup') => {
-									#renderfield -> append(#optionitem -> value
-										+ (!#onefield -> find('linebreak') ? ('<br />\n')))
+								#optioncount += 1
+//								#renderfield -> append( (#optioncount > 1 && #linebreak) ? ('<br />') + '\n')
+								if(#optionitem -> name == '-optgroup') => {
+									#renderfield -> append((!#linebreak && #optioncount > 1) ? ('\n<br />'))
+									if(#optionitem -> value != '-optgroup') => {
+										#renderfield -> append(#optionitem -> value
+											+ (!#linebreak ? ('<br />\n')))
+									}
+								else
+									#renderfield -> append('<label class="radio ' + (#linebreak ? ' inline') + '"><input type="radio"'
+										+ string_replaceregexp(#renderfield_base, -find = 'id="(.+?)"', -replace = ('id="\\1_' + #optioncount + '"'))
+										+ ' value="' + encode_html(#optionitem -> name) + '"')
+									if(#optionitem -> name != '' && #fieldvalue_array >> #optionitem -> name) => {
+										#renderfield -> append(' checked="checked"')
+									}
+									#renderfield -> append(#endslash + '> ' + #optionitem -> value + '</label>\n')
 								}
-							else
-								#renderfield -> append('<input type="radio"'
-									+ string_replaceregexp(#renderfield_base, -find = 'id="(.+?)"', -replace = ('id="\\1_' + #optioncount + '"'))
-									+ ' value="' + encode_html(#optionitem -> name) + '"')
-								if(#optionitem-> name != '' && #fieldvalue_array >> #optionitem -> name) => {
-									#renderfield -> append(' checked="checked"')
-								}
-								if(!.'noscript' && !#nowarning) => {
-									#renderfield -> append(' onclick="makedirty();"')
-								}
-								#renderfield -> append(#endslash + '> <label for="' + #id + '_' + #optioncount
-									+ '" id="' + #id + '_' + #optioncount + '_label"')
-								if(!.'noscript' && !#nowarning) => {
-									#renderfield -> append(' onclick="makedirty();"')
-								}
-								#renderfield -> append('>' + #optionitem -> value + '</label> ')
 							}
+							#renderfield -> append('</div>\n')
+						else
+							#linebreak = #onefield -> find('linebreak')
+							local(optioncount = integer)
+							#renderfield -> append('<div class="inputgroup'
+								+ (#onefield -> find('class') -> size > 0 ?  ' ' + (#onefield -> find('class'))
+								| (#defaultclass != '' ? ' ' + #defaultclass) )
+								+ '" id="' + #id + '">\n')
+
+							with optionitem in #options do => {
+
+								#optioncount += 1
+								#renderfield -> append(((#optioncount > 1 && #linebreak) ? ('<br />') )+ '\n')
+								if(#optionitem -> name == '-optgroup') => {
+									#renderfield -> append((!#linebreak && #optioncount > 1) ? ('\n<br />'))
+									if(#optionitem -> value != '-optgroup') => {
+										#renderfield -> append(#optionitem -> value
+											+ (!#linebreak ? ('<br />\n')))
+									}
+								else
+									#renderfield -> append('<input type="radio"'
+										+ string_replaceregexp(#renderfield_base, -find = 'id="(.+?)"', -replace = ('id="\\1_' + #optioncount + '"'))
+										+ ' value="' + encode_html(#optionitem -> name) + '"')
+									if(#optionitem-> name != '' && #fieldvalue_array >> #optionitem -> name) => {
+										#renderfield -> append(' checked="checked"')
+									}
+									if(!.'noscript' && !#nowarning) => {
+										#renderfield -> append(' onclick="makedirty();"')
+									}
+									#renderfield -> append(#endslash + '> <label for="' + #id + '_' + #optioncount
+										+ '" id="' + #id + '_' + #optioncount + '_label"')
+									if(!.'noscript' && !#nowarning) => {
+										#renderfield -> append(' onclick="makedirty();"')
+									}
+									#renderfield -> append('>' + #optionitem -> value + '</label> ')
+								}
+							}
+							#renderfield -> append('</div>\n')
 						}
-						#renderfield -> append('</div>\n')
+
 					case('select')
 						#renderfield -> append('<select '
 							+ #renderfield_base
@@ -1656,7 +1761,7 @@ Outputs HTML for the form fields, a specific field, a range of fields or all fie
 							}
 						}
 						#renderfield -> append('>\n')
-						if(#onefield -> find('default') != '' && #onefield ->find('size') <= 1) => {
+						if(#onefield -> find('default') -> size > 0 && #onefield ->find('size') <= 1) => {
 							#renderfield -> append('<option value="">' + encode_html(#onefield -> find('default')) + '</option>\n<option value=""></option>\n')
 						}
 						local(optgroup_open = false)
@@ -1682,26 +1787,40 @@ Outputs HTML for the form fields, a specific field, a range of fields or all fie
 						}
 						#renderfield -> append('</select>\n')
 					case('submit')
-						#renderfield -> append('<input type="submit"'
-							+ #renderfield_base
-							+ ' value="' + encode_html(#fieldvalue) + '"')
-						if(.formmode == 'add'
-							&& !#onefield -> find('disabled') // already disabled
-							&& (#onefield -> find('originaltype') == 'savebutton' || #onefield -> find('originaltype') == 'deletebutton'
-							|| #onefield -> find('name') == 'button_save' || #onefield -> find('name') == 'button_delete')) => {
-							#renderfield -> append(' disabled="disabled"')
+						if(#bootstrap) => {
+							#renderfield -> append('<button type="submit"'
+								+ #renderfield_base)
+							if(.formmode == 'add'
+								&& !#onefield -> find('disabled') // already disabled
+								&& (#onefield -> find('originaltype') == 'savebutton' || #onefield -> find('originaltype') == 'deletebutton'
+								|| #onefield -> find('name') == 'button_save' || #onefield -> find('name') == 'button_delete')) => {
+								#renderfield -> append(' disabled="disabled"')
+							}
+
+							#renderfield -> append('>' + #fieldvalue + '</button>')
+
+						else
+							#renderfield -> append('<input type="submit"'
+								+ #renderfield_base
+								+ ' value="' + encode_html(#fieldvalue) + '"')
+							if(.formmode == 'add'
+								&& !#onefield -> find('disabled') // already disabled
+								&& (#onefield -> find('originaltype') == 'savebutton' || #onefield -> find('originaltype') == 'deletebutton'
+								|| #onefield -> find('name') == 'button_save' || #onefield -> find('name') == 'button_delete')) => {
+								#renderfield -> append(' disabled="disabled"')
+							}
+							if(!.'noscript'
+								&& (#onefield ->find('name') == 'button_delete'
+									|| #onefield ->find('originaltype') == 'deletebutton'
+									|| #onefield ->find('confirmmessage') != '')) => {
+								local(confirmmessage = (#onefield -> find('confirmmessage') -> size > 0
+									? #onefield -> find('confirmmessage') | 'Really delete?'))
+								#confirmmessage ->replace('"', '&quot;')
+								#confirmmessage ->replace('\'', '\\\'')
+								#renderfield -> append(' onclick="return confirm(\'' + #confirmmessage +  '\')"')
+							}
+							#renderfield -> append(#endslash + '>')
 						}
-						if(!.'noscript'
-							&& (#onefield ->find('name') == 'button_delete'
-								|| #onefield ->find('originaltype') == 'deletebutton'
-								|| #onefield ->find('confirmmessage') != '')) => {
-							local(confirmmessage = (#onefield -> find('confirmmessage') -> size > 0
-								? #onefield -> find('confirmmessage') | 'Really delete?'))
-							#confirmmessage ->replace('"', '&quot;')
-							#confirmmessage ->replace('\'', '\\\'')
-							#renderfield -> append(' onclick="return confirm(\'' + #confirmmessage +  '\')"')
-						}
-						#renderfield -> append(#endslash + '>')
 					case('reset')
 						#renderfield -> append('<input type="reset"'
 							+ #renderfield_base
@@ -2070,7 +2189,6 @@ Outputs HTML for the form fields, a specific field, a range of fields or all fie
 		return(#output)
 
 		///protect
-// 	} // end debug
 	} // end renderform
 
 	public renderform(
@@ -2083,13 +2201,14 @@ Outputs HTML for the form fields, a specific field, a range of fields or all fie
 		-start::boolean = false,
 		-end::boolean = false,
 		-onlyformcontent::boolean = false,
+		-bootstrap::boolean = false,
 		-xhtml::boolean = false   // xhtml =  boolean, if set to true adjust output for XHTML
 
 		) => {
 
 		#start ? return(.renderformstart(#xhtml))	// only output the starting <form> tag
 		#end ? return(.renderformend(#xhtml))	// only output the end </form> tag
-		return .renderform(#name, #from, #to, #type, #excludetype, #legend, #xhtml, #onlyformcontent)
+		return .renderform(#name, #from, #to, #type, #excludetype, #legend, #xhtml, #onlyformcontent, #bootstrap)
 	}
 
 /**!
@@ -2123,9 +2242,11 @@ Outputs form data as plain HTML, a specific field, a range of fields or all fiel
 		local(renderrow = string)
 		local(fieldvalue = string)
 		local(fieldvalue_array = array)
+		local(fieldtype = string)
 		local(options = array)
 		local(usehint = array)
 		local(loopcount = 0)
+		local(linebreak = false)
 
 		// local var that adjust tag endings if rendered for XHTML
 		local(endslash = (.xhtml(params) ? ' /' | ''))
@@ -2170,6 +2291,8 @@ Outputs form data as plain HTML, a specific field, a range of fields or all fiel
 
 			#onefield = .'fields' -> get(loop_count) -> value
 
+			#fieldtype = #onefield -> find('type')
+
 			#fieldvalue = #onefield ->find('value') -> ascopy
 			#fieldvalue_array = #fieldvalue
 			if(!#fieldvalue_array -> isa(::array)) => {
@@ -2184,6 +2307,7 @@ Outputs form data as plain HTML, a specific field, a range of fields or all fiel
 			if(#onefield >> 'options') => {
 				#options = #onefield -> find('options')
 				// convert types for pair
+				#options -> isa(::string) ? #options = array(#options)
 				with optionitem in #options do => {
 					if(!#optionitem -> isa(::pair)) => {
 						#optionitem = pair(#optionitem = #optionitem)
@@ -2196,58 +2320,60 @@ Outputs form data as plain HTML, a specific field, a range of fields or all fiel
 
 			if(loop_count >= #from
 				&& loop_count <= #to
-				&& #type >> #onefield -> find('type')
+				&& #type >> #fieldtype
 				&& !(#excludetype >> #onefield ->find('type'))) => {
 
-				if(map('submit', 'reset', 'image') >> #onefield -> find('type')) => {
+				if(map('submit', 'reset', 'image') >> #fieldtype) => {
 					#renderrow = #buttontemplate -> ascopy
 				else
 					#renderrow = #template -> ascopy
 				}
 
-				if(.'exceptionfieldtypes' >> #onefield -> find('type')) => {
+				if(.'exceptionfieldtypes' >> #fieldtype) => {
 					#renderrow -> replace('#label#:', '')
-					#renderrow -> replace('#label#', '')
+					#renderrow -> replace('#required#', '')
 				else(#onefield -> find('label') != '')
 					#renderrow -> replace('#label#', encode_html(#onefield -> find('label')) )
 				else
 					#renderrow -> replace('#label#:', '')
-					#renderrow -> replace('#label#', '')
+					#renderrow -> replace('#required#', '')
 				}
 				if(map('radio', 'checkbox', 'select') >> #onefield ->find('type')) => {
+					#linebreak = #onefield -> find('linebreak')
 					#renderfield = string
 					#loopcount = 0
 					with onefieldvalue in #fieldvalue_array do => {
 						#loopcount += 1
 						if(#loopcount > 1) => {
-							#renderfield -> append(#onefield -> find('linebreak') ? ('<br />\n') | ', ')
+							#renderfield -> append(#linebreak ? ('<br />\n') | ', ')
 						}
 						if(#options >> #onefieldvalue) => {
 							// show the display text for a selected option
-							#renderfield -> append(encode_break(#options ->find(#onefieldvalue) -> first -> value))
+							local(thisonefieldvalue = #options ->find(#onefieldvalue) -> first)
+							#renderfield -> append(encode_break(string(#thisonefieldvalue -> isa(::pair) ? #thisonefieldvalue -> value | #thisonefieldvalue)))
 						else
 							// show the option value itself
-							#renderfield -> append(encode_break(#onefieldvalue))
+							#renderfield -> append(encode_break(string(#onefieldvalue)))
 						}
 					}
-				else(#onefield -> find('type') == 'html')
+				else(#fieldtype == 'html')
 					#renderrow = #template
 					#renderrow -> replace('#label#', '')
 					#renderrow -> replace('#required#', '')
 					#renderfield = (#fieldvalue + '\n')
-				else(#onefield -> find('type') == 'legend')
+				else(#fieldtype == 'legend')
 					#renderrow = ''
 					if(.'render_fieldset_open') => {
-						#output -> append('checking_first</fieldset>\n')
+						#output -> append('</fieldset>\n')
 						.'render_fieldset_open' = false
 					}
 					#output -> append('<fieldset>\n')
-					#output -> append('<legend>checking_aha' + encode_html(#fieldvalue) + '</legend>')
+					#output -> append('<legend>' + encode_html(#fieldvalue) + '</legend>')
 					.'render_fieldset_open' = true
-				else(#onefield -> find('type') == 'fieldset')
+				else(#fieldtype == 'fieldset')
 					#renderrow = ''
 					if(.'render_fieldset_open') => {
-						#output -> append('checking_second</fieldset>\n')
+						#output -> append('</fieldset>\n')
 						.'render_fieldset_open' = false
 					}
 					if(#fieldvalue != false) => {
@@ -2265,7 +2391,7 @@ Outputs form data as plain HTML, a specific field, a range of fields or all fiel
 		if(#legend!='' && .'render_fieldset2_open') => {
 			// inner fieldset is open
 			.'render_fieldset2_open' = false
-			#output -> append('checking_third</fieldset>\n')
+			#output -> append('</fieldset>\n')
 		}
 		return(#output)
 
@@ -2370,15 +2496,15 @@ Sets the param content for a form field.
 					#_name = #value
 
 				case(#param == 'size' || #param == 'rows' || #param == 'cols')
-					fail_if(!#value -> isa('integer'), -9956, 'The specified value not of the correct type (not integer)')
+					fail_if(!#value -> isa(::integer), -9956, 'The specified value not of the correct type (not integer)')
 
 				case(#param == 'multiple' || #param == 'linebreak' || #param == 'focus' || #param == 'disabled' || #param == 'required' || #param == 'nowarning')
 
-					fail_if(!#value -> isa('boolean'), -9956, 'The specified value not of the correct type (not boolean)')
+					fail_if(!#value -> isa(::boolean), -9956, 'The specified value not of the correct type (not boolean)')
 
 				case(#param == 'options')
 
-					fail_if(!#value -> isa('array') && !#value -> isa('set'), -9956, 'The specified value not of the correct type (not array or set)')
+					fail_if(!#value -> isa(::array) && !#value -> isa(::set), -9956, 'The specified value not of the correct type (not array or set)')
 
 			}
 
@@ -2524,5 +2650,5 @@ Internal member tag. Adds needed javascripts through an atend handler that will 
 	}
 
 }
-log_critical('loading knop_form done')
+//log_critical('loading knop_form done')
 ?>

--- a/knop9/knoplibs/knop_grid.lasso
+++ b/knop9/knoplibs/knop_grid.lasso
@@ -8,12 +8,16 @@ Custom type to handle data grids (record listings).
 define knop_grid => type {
 	parent knop_base
 
-	data public version = '2012-05-18'
+	data public version = '2012-10-30'
 
 /*
 
 CHANGE NOTES
 
+	2012-10-30	JC	Fixed bug preventing quicksearch hint and input field to work properly
+	2012-10-21	JC	Changed old style if to Lasso 9 proper. Removed quotes from local declarations. Replaced .'xxx' with 'xxx. Replaced iterate with query expression. Replaced += with append.
+	2012-10-21	JC	Added support for bootstrap quicksearch form
+	2012-10-21	JC	Changed -> type == 'xxx' to -> isa(::xxx)
 	2012-05-19	JC	Added -getargs = false when creating url_cached
 	2012-05-18	JC	Fixed bug that would not populate dbfield and label if only a name param was supplied
 	2011-12-20	JC	Added support for jquery row sorting
@@ -47,11 +51,11 @@ Move templates to a member tag to be make it easier to subclass
 	data public database
 	data public nav = null
 
-	data public quicksearch::string = 'Quicksearch'
+	data public quicksearch_string::string = 'Quicksearch'
 	data public quicksearch_form
 	data public quicksearch_form_reset
-	data public rawheader::string = ''
-	data public class::string = ''
+	data public rawheader::string = string
+	data public class::string = string
 
 	data public tbl_id::string = 'grid'
 	data public qs_id::string = 'quicksearch'
@@ -81,18 +85,20 @@ Parameters:\n\
 **/
 	public oncreate(
 		database::knop_database,
-		nav::any = '',
+		nav::any = string,
 		quicksearch = false,
-		rawheader::string = '',
-		class::string = '',
-		id::string = '',
+		rawheader::string = string,
+		class::string = string,
+		id::string = string,
 		nosort = false,
 		language::string = 'en',
 		numbered::any = false,
-		rowsorting::boolean = false
+		rowsorting::boolean = false,
+		quicksearch_btnclass = string
 		) => {
 
-		local('lang' = .'lang')
+		local(lang = .'lang')
+
 		#lang -> addlanguage(-language = 'en', -strings = map(
 			'quicksearch_showall' = 'Show all',
 			'quicksearch_search' = 'Search',
@@ -139,72 +145,76 @@ Parameters:\n\
 
 		//need to review and address the following functionality TT Feb4, 2011
 		// the following params are stored as reference, so the values of the params can be altered after adding a field simply by changing the referenced variable.
-		.'database' = #database
-		#nav -> isa('knop_nav') ? .'nav' = #nav
+		.database = #database
+		#nav -> isa(::knop_nav) ? .nav = #nav
 
-		.'nosort' = #nosort
-		.'rowsorting' = #rowsorting
 
-		.'numbered' = (#numbered != false ? integer(#numbered) | false)
+		.nosort = #nosort
+		.rowsorting = #rowsorting
+
+		.numbered = (#numbered != false ? integer(#numbered) | false)
 
 		#class -> size > 0 ?
-			.'class' = #class
+			.class = #class
 
-		if(#id -> size > 0);
-			.'tbl_id' = #id + '_grid';
-			.'qs_id' = #id + '_quicksearch';
-			.'qsr_id' = #id + '_qs_reset';
-		/if;
+		if(#id -> size > 0) => {
+			.tbl_id = #id + '_grid'
+			.qs_id = #id + '_quicksearch'
+			.qsr_id = #id + '_qs_reset'
+		}
 
-		local('clientparams' = knop_client_params)
+		local(clientparams = knop_client_params)
 
-		if(!.'nosort')
-			.'sortfield' = (#clientparams >> '-sort' ? string(#clientparams -> find('-sort') -> first -> value) | string);
-			.'sortdescending' = (#clientparams >> '-desc')
-		/if
-		.'page' = (#clientparams >> '-page' ? integer(#clientparams -> find('-page') -> first -> value) | 1)
-		.'page' < 1 ? .'page' = 1
 
-		if(#quicksearch != false) => {
+		if(!.nosort) => {
+			.sortfield = (#clientparams >> '-sort' ? string(#clientparams -> find('-sort') -> first -> value) | string)
+			.sortdescending = (#clientparams >> '-desc')
+		}
+		.page = (#clientparams >> '-page' ? integer(#clientparams -> find('-page') -> first -> value) | 1)
+		.page < 1 ? .page = 1
 
-			.'quicksearch' = (#quicksearch -> isa(::string) && #quicksearch -> size > 0 ? #quicksearch | 'Quicksearch')
+		if(#quicksearch) => {
 
-			.'quicksearch_form' = knop_form(-name = 'quicksearch', -id = .'qs_id', -formaction = './', -method = 'get', -template = '#field#\n', -noautoparams)
-			.'quicksearch_form_reset' = knop_form(-name = 'quicksearch_reset', -id = .'qsr_id', -formaction = './', -method = 'get', -template = '#field#\n', -noautoparams)
-			local('autosavekey' = server_name + response_path)
-			if(.'nav'-> type == 'knop_nav' && .'nav' -> 'navmethod'=='param')
-				.'quicksearch_form' -> addfield(-type = 'hidden', -name = '-path', -value= .'nav' -> path)
-				.'quicksearch_form_reset' -> addfield(-type = 'hidden', -name = '-path', -value = .'nav' -> path)
+			#quicksearch -> isa(::string) && #quicksearch -> size > 0 ? .quicksearch_string = #quicksearch
+			.quicksearch_form = knop_form(-name = 'quicksearch', -id = .qs_id, -formaction = './', -method = 'get', -template = '#field#\n', -class= 'form-search', -noautoparams)
+			.quicksearch_form_reset = knop_form(-name = 'quicksearch_reset', -id = .qsr_id, -formaction = './', -method = 'get', -template = '#field#\n', -class= 'form-search', -noautoparams)
+			local(autosavekey = server_name + response_path)
+			if(.nav-> isa(::knop_nav) && .nav -> 'navmethod'=='param') => {
+				.quicksearch_form -> addfield(-type = 'hidden', -name = '-path', -value= .nav -> path)
+				.quicksearch_form_reset -> addfield(-type = 'hidden', -name = '-path', -value = .nav -> path)
 				#autosavekey -> removetrailing('/')
-				#autosavekey += ('/' + .'nav' -> path)
-			/if
-			if(.'sortfield' != '' && !.'nosort')
-				.'quicksearch_form' -> addfield(-type = 'hidden', -name = '-sort', -value = .'sortfield')
-				.'quicksearch_form_reset' -> addfield(-type = 'hidden', -name = '-sort', -value = .'sortfield')
-				if(.'sortdescending')
-					.'quicksearch_form' -> addfield(-type = 'hidden', -name = '-desc')
-					.'quicksearch_form_reset' -> addfield(-type = 'hidden', -name = '-desc')
-				/if
-			/if
-			if(client_type >> 'WebKit')
+				#autosavekey -> append('/' + .nav -> path)
+			}
+
+			if(.sortfield != '' && !.nosort) => {
+				.quicksearch_form -> addfield(-type = 'hidden', -name = '-sort', -value = .sortfield)
+				.quicksearch_form_reset -> addfield(-type = 'hidden', -name = '-sort', -value = .sortfield)
+				if(.sortdescending) => {
+					.quicksearch_form -> addfield(-type = 'hidden', -name = '-desc')
+					.quicksearch_form_reset -> addfield(-type = 'hidden', -name = '-desc')
+				}
+			}
+			if(client_type >> 'WebKit') => {
 				// only use<input type=search" for WebKit based browsers like Safari
-				.'quicksearch_form' -> addfield(-type = 'search', -name = '-q', -hint = .'quicksearch', -size = 15, -id = .'qs_id' + '_q', -raw = ('autosave="' + #autosavekey + '" results="10"'))
+				.quicksearch_form -> addfield(-type = 'search', -name = '-q', -hint = .quicksearch_string, -size = 16, -id = .qs_id + '_q', -class = 'search-query', -raw = ('autosave="' + #autosavekey + '" results="10"'))
 			else
-				.'quicksearch_form' -> addfield(-type = 'text', -name = '-q', -hint = .'quicksearch', -size = 15, -id = .'qs_id' + '_q')
-			/if
-			.'quicksearch_form' -> addfield(-type = 'submit', -name = 's', -value = #lang -> getstring('quicksearch_search'))
-			if(#clientparams >> '-q')
-				.'quicksearch_form' -> setvalue('-q' = #clientparams -> find('-q') -> first -> value)
-				.'quicksearch_form_reset' -> addfield(-type = 'submit', -name = 'a', -value = #lang -> getstring('quicksearch_showall'))
+				.quicksearch_form -> addfield(-type = 'text', -name = '-q', -hint = .quicksearch_string, -size = 16, -id = .qs_id + '_q', -class = 'search-query')
+			}
+			.quicksearch_form -> addfield(-type = 'submit', -name = 's', -class = #quicksearch_btnclass, -value = #lang -> getstring('quicksearch_search'))
+			if(#clientparams >> '-q') => {
+				.quicksearch_form -> setvalue('-q' = #clientparams -> find('-q') -> first -> value)
+				.quicksearch_form_reset -> addfield(-type = 'submit', -name = 'a', -class = #quicksearch_btnclass, -value = #lang -> getstring('quicksearch_showall'))
 			else
-				.'quicksearch_form_reset' -> addfield(-type = 'submit', -name = 'a', -value = #lang -> getstring('quicksearch_showall'), -disabled)
-			/if
+				.quicksearch_form_reset -> addfield(-type = 'submit', -name = 'a', -class = #quicksearch_btnclass, -value = #lang -> getstring('quicksearch_showall'), -disabled)
+			}
+
 
 		}
 
 		/* Added by JC 071111 to handle extra form included in the header */
 
-		.'rawheader' = #rawheader
+		.rawheader = #rawheader
+
 
 	}
 
@@ -212,27 +222,22 @@ Parameters:\n\
 		-database::knop_database,
 		-nav::any = knop_nav,
 		-quicksearch = false,
-		-rawheader::string = '',
-		-class::string = '',
-		-id::string = '',
+		-rawheader::string = string,
+		-class::string = string,
+		-id::string = string,
 		-nosort = false,
-		-language::string = '',
+		-language::string = string,
 		-numbered = false,
-		-rowsorting::boolean = false
-		) => .oncreate(#database, #nav, #quicksearch, #rawheader, #class, #id, #nosort, #language, #numbered, #rowsorting)
+		-rowsorting::boolean = false,
+		-quicksearch_btnclass = string
+		) => .oncreate(#database, #nav, #quicksearch, #rawheader, #class, #id, #nosort, #language, #numbered, #rowsorting, #quicksearch_btnclass)
 
 	public onassign(value) => {
-		local('description' = 'Internal, needed to restore references when ctype is defined as prototype')
+		local(description = 'Internal, needed to restore references when ctype is defined as prototype')
 		// recreate references here
-		.'database' = #value -> 'database'
-		.'nav' = #value -> 'nav'
+		.database = #value -> 'database'
+		.nav = #value -> 'nav'
 	}
-
-/**!
-lang
-Returns a reference to the language object
-**/
-	public lang => .'lang'
 
 /**!
 insert
@@ -257,26 +262,26 @@ Adds a column to the record listing. \n\
 Previously called addfield
 **/
 	public insert(
-			name::string = '',
+			name::string = string,
 			label::string = #name,
 			dbfield::string = #name,
 			width::integer = -1,
-			class = '',
-			raw = '', // TODO: not implemented
-			url = '',
+			class = string,
+			raw = string, // TODO: not implemented
+			url = string,
 			keyparamname::string = '-keyvalue',
 			defaultsort::any = false,
 			nosort::boolean = false,
-			template = '',
+			template = string,
 			quicksearch::any = false
 		) => {
 
-		fail_if(#template -> type != 'string'
-			&& #template -> type != 'map'
-			&& #template -> type != 'capture'
-			&& #template -> type != 'tag', -1, 'Template must be either string, map or compound expression')
+		local(template_type = string(#template -> type))
 
-		local('field' = map)
+
+		fail_if(array('string', 'map', 'capture', 'tag') !>> #template_type, -1, 'Template must be either string, map or compound expression')
+
+		local(field = map)
 		#name -> size > 0 ? #field -> insert('name' = #name)
 		#class -> size > 0 ? #field -> insert('class' = #class)
 		#raw -> size > 0 ? #field -> insert('raw' = #raw)
@@ -284,48 +289,49 @@ Previously called addfield
 		#field -> insert('keyparamname' = #keyparamname)
 		#width > -1 ? #field -> insert('width' = #width)
 
-		#template -> isa('capture') || #template -> isa('tag') || #template -> size > 0 ? #field -> insert('template' = (#template -> type == 'string' ? map('-default' = #template) | #template))
+		#template_type == 'capture' || #template_type == 'tag' || #template -> size > 0 ? #field -> insert('template' = (#template_type == 'string' ? map('-default' = #template) | #template))
 
-		if(#name -> size > 0)
+		if(#name -> size > 0) => {
 			#field -> insert('label' = #label)
 			#field -> insert('dbfield' = #dbfield )
 			#field -> insert('nosort' = #nosort)
-			if(#defaultsort != false && .'defaultsort' -> size == 0)
-				.'defaultsort' = #name
-				if(.'sortfield' -> size == 0)
-					.'sortfield' = .'defaultsort'
-					if(string(#defaultsort) == 'desc' || string(#defaultsort) == 'descending')
-						.'sortdescending' = true
-					/if
-				/if
-			/if
-			.'dbfieldmap' -> insert(#name = #dbfield)
-		/if
+			if(#defaultsort != false && .defaultsort -> size == 0) => {
+				.defaultsort = #name
+				if(.sortfield -> size == 0) => {
+					.sortfield = .defaultsort
+					if(string(#defaultsort) == 'desc' || string(#defaultsort) == 'descending') => {
+						.sortdescending = true
+					}
+				}
+			}
+			.dbfieldmap -> insert(#name = #dbfield)
+		}
 		// changed by Jolle 2011-06-18 to allow different quicksearch field name than
 		if(#quicksearch -> isa(::boolean) && #quicksearch) => {
-			.'quicksearch_fields' -> insert( #dbfield)
+			.quicksearch_fields -> insert( #dbfield)
 		else(#quicksearch -> isa(::string) && #quicksearch -> size > 0)
-			.'quicksearch_fields' -> insert( #quicksearch)
+			.quicksearch_fields -> insert( #quicksearch)
 		}
 
-		if(#name -> size > 0 || #label -> size > 0)
-			.'fields' -> insert(#field)
-		/if
+		if(#name -> size > 0 || #label -> size > 0) => {
+			.fields -> insert(#field)
+		}
+
 
 	}
 
 	public insert(
-			-name::string = '',
+			-name::string = string,
 			-label::string = #name,
 			-dbfield::string = #name,
 			-width::integer = -1,
-			-class::string = '',
-			-raw = '', // TODO: not implemented
-			-url::string = '',
+			-class::string = string,
+			-raw = string, // TODO: not implemented
+			-url::string = string,
 			-keyparamname::string = '-keyvalue',
 			-defaultsort::any = false,
 			-nosort::boolean = false,
-			-template = '',
+			-template = string,
 			-quicksearch::any = false
 		) => .insert(#name, #label, #dbfield, #width, #class, #raw, #url, #keyparamname, #defaultsort, #nosort, #template, #quicksearch)
 
@@ -334,32 +340,32 @@ addfield
 deprecated use insert instead
 **/
 	public addfield(
-			name::string = '',
+			name::string = string,
 			label::string = #name,
 			dbfield::string = #name,
 			width::integer = -1,
-			class = '',
-			raw = '', // TODO: not implemented
-			url = '',
+			class = string,
+			raw = string, // TODO: not implemented
+			url = string,
 			keyparamname::string = '-keyvalue',
 			defaultsort::any = false,
 			nosort::boolean = false,
-			template = '',
+			template = string,
 			quicksearch::any = false
 		) => .insert(#name, #label, #dbfield, #width, #class, #raw, #url, #keyparamname, #defaultsort, #nosort, #template, #quicksearch)
 
 	public addfield(
-			-name::string = '',
+			-name::string = string,
 			-label::string = #name,
 			-dbfield::string = #name,
 			-width::integer = -1,
-			-class::string = '',
-			-raw = '', // TODO: not implemented
-			-url::string = '',
+			-class::string = string,
+			-raw = string, // TODO: not implemented
+			-url::string = string,
 			-keyparamname::string = '-keyvalue',
 			-defaultsort::any = false,
 			-nosort::boolean = false,
-			-template = '',
+			-template = string,
 			-quicksearch::any = false
 		) => .insert(#name, #label, #dbfield, #width, #class, #raw, #url, #keyparamname, #defaultsort, #nosort, #template, #quicksearch)
 
@@ -372,30 +378,30 @@ Parameters:
 **/
 	public sortparams(sql::boolean = false, removedotbackticks::boolean = false) => {
 
-		if(#sql)
-			fail_if(.'database' -> 'isfilemaker', 7009, '-sql can not be used with FileMaker')
-			.'sortfield' == '' ? return string;
-			local('output' = string);
-			if(.'dbfieldmap' >> .'sortfield')
-				#output = ' ORDER BY '
-				if(#removedotbackticks)
-					#output += ('`' + knop_stripbackticks((.'dbfieldmap') -> find(.'sortfield')) + '`')
+		if(#sql) => {
+			fail_if(.database -> 'isfilemaker', 7009, '-sql can not be used with FileMaker')
+			.sortfield == '' ? return string
+			local(output = string)
+			if(.dbfieldmap >> .sortfield) => {
+				#output -> append(' ORDER BY ')
+				if(#removedotbackticks) => {
+					#output -> append('`' + knop_stripbackticks((.dbfieldmap) -> find(.sortfield)) + '`')
 				else
-					#output += ('`' + string_replace(knop_stripbackticks((.'dbfieldmap') -> find(.'sortfield')), -find = '.', -replace = '`.`') + '`')
-				/if
+					#output -> append('`' + string_replace(knop_stripbackticks((.dbfieldmap) -> find(.sortfield)), -find = '.', -replace = '`.`') + '`')
+				}
 
-				.'sortdescending' ? #output += ' DESC'
+				.sortdescending ? #output -> append(' DESC')
 
-			/if
+			}
 		else
-			local('output' = array)
-			.'sortfield' == '' ? return #output
-			if(.'dbfieldmap' >> .'sortfield')
-				#output -> insert(-sortfield = .'dbfieldmap' -> find(.'sortfield') )
-				.'sortdescending' ? #output -> insert(-sortorder = 'descending')
+			local(output = array)
+			.sortfield == '' ? return #output
+			if(.dbfieldmap >> .sortfield) => {
+				#output -> insert(-sortfield = .dbfieldmap -> find(.sortfield) )
+				.sortdescending ? #output -> insert(-sortorder = 'descending')
 
-			/if
-		/if
+			}
+		}
 
 		return #output
 	}
@@ -413,117 +419,121 @@ Returns a pair array with fieldname = value to use in a search inline. If you sp
 			-value (optional flag) Output just the search value of the quicksearch field instead of a pair array or SQL string\n\
 			-removedotbackticks (optional flag) Use with -sql for backward compatibility for fields that contain periods.  If you use periods in a fieldname then you cannot use a JOIN in Knop.
 **/
-	public quicksearch(sql::boolean = false, contains::boolean = false, value::boolean = false, removedotbackticks::boolean = false) => {
+	public quicksearch(
+		sql::boolean = false,
+		contains::boolean = false,
+		value::boolean = false,
+		removedotbackticks::boolean = false
+	) => {
 
-		local('output' = array)
-		local('output_temp' = array)
-		local('_sql' = #sql -> ascopy)
-		local('wordseparators' = array(',', '.', '-', ' ', '(', '"', '@', '\n', '\r')) // \r and \n must not come after each other as \r\n, but \n\r is fine.
-		local('fieldvalue' = string(.'quicksearch_form' != NULL ? .'quicksearch_form' -> getvalue('-q')))
-		local('onevalue' = '')
-		local('field' = '')
 
-		fail_if(#_sql && .'database' -> 'isfilemaker', 7009, '-sql can not be used with FileMaker')
+		local(output = array)
+		local(output_temp = array)
+		local(_sql = #sql -> ascopy)
+		local(wordseparators = array(',', '.', '-', ' ', '(', '"', '@', '\n', '\r')) // \r and \n must not come after each other as \r\n, but \n\r is fine.
+		local(fieldvalue = string(.quicksearch_form != NULL ? .quicksearch_form -> getvalue('-q')))
 
-		if(.'quicksearch_form' -> type != 'knop_form')
+		fail_if(#_sql && .database -> 'isfilemaker', 7009, '-sql can not be used with FileMaker')
+
+		if(not .quicksearch_form -> isa(::knop_form)) => {
 			#_sql ? return string | return array
 
-		/if
-		#value ? return(string(.'quicksearch_form' -> getvalue('-q')))
+		}
+		#value ? return(string(.quicksearch_form -> getvalue('-q')))
 
-		if(#fieldvalue != '')
+		if(#fieldvalue != '') => {
 
-			if(.'database' -> 'isfilemaker')
+			if(.database -> 'isfilemaker') => {
 				#output -> insert(-logicaloperator = 'or')
-				iterate(.'quicksearch_fields')
+				with val in .quicksearch_fields do {
 					#contains ? #output -> insert(-op = 'cn')
-					#output -> insert(loop_value = #fieldvalue)
-				/iterate
+					#output -> insert(#val = #fieldvalue)
+				}
 			else
 				// search each word separately
-				#fieldvalue = #fieldvalue -> split(' ')
-				iterate(#fieldvalue, #onevalue)
-					#output_temp = array;
-					iterate(.'quicksearch_fields', #field)
-						if(#_sql)
-							if(#contains)
-								if(#removedotbackticks);
+				with onevalue in #fieldvalue -> split(' ') do {
+					#output_temp = array
+					with field in .quicksearch_fields do {
+						if(#_sql) => {
+							if(#contains) => {
+								if(#removedotbackticks) => {
 									#output_temp -> insert('`' + knop_stripbackticks(encode_sql(#field)) + '`'
-										+ ' LIKE "%' + knop_encodesql_full(#onevalue ) + '%"');
-								else;
+										+ ' LIKE "%' + knop_encodesql_full(#onevalue ) + '%"')
+								else
 									#output_temp -> insert('`' + string_replace(knop_stripbackticks(encode_sql(#field)), -find = '.', -replace = '`.`') + '`'
-										+ ' LIKE "%' + knop_encodesql_full(#onevalue ) + '%"');
-								/if;
+										+ ' LIKE "%' + knop_encodesql_full(#onevalue ) + '%"')
+								}
 
-							else;
-								if(#removedotbackticks);
+							else
+								if(#removedotbackticks) => {
 									#output_temp -> insert('`' + knop_stripbackticks(encode_sql(#field)) + '`'
-									+ ' LIKE "' + knop_encodesql_full(#onevalue ) + '%"');
-								else;
+									+ ' LIKE "' + knop_encodesql_full(#onevalue ) + '%"')
+								else
 									#output_temp -> insert('`' + string_replace(knop_stripbackticks(encode_sql(#field)), -find = '.', -replace = '`.`') + '`'
-									+ ' LIKE "' + knop_encodesql_full(#onevalue ) + '%"');
-								/if;
+									+ ' LIKE "' + knop_encodesql_full(#onevalue ) + '%"')
+								}
 
 								// basic emulation of "word begins with"
-								iterate(#wordseparators) => {
-									if(#removedotbackticks);
+								with val in #wordseparators do {
+									if(#removedotbackticks) => {
 										#output_temp -> insert('`' + knop_stripbackticks(encode_sql(#field)) + '`'
-											+ ' LIKE "%' + knop_encodesql_full(loop_value + #onevalue ) + '%"');
-									else;
+											+ ' LIKE "%' + knop_encodesql_full(#val + #onevalue ) + '%"')
+									else
 										#output_temp -> insert('`' + string_replace(knop_stripbackticks(encode_sql(#field)), -find = '.', -replace = '`.`') + '`'
-											+ ' LIKE "%' + knop_encodesql_full(loop_value + #onevalue ) + '%"');
-									/if;
+											+ ' LIKE "%' + knop_encodesql_full(#val + #onevalue ) + '%"')
+									}
 
 								}
-							/if
+							}
 						else
-							if(#contains)
+							if(#contains) => {
 								#output_temp -> insert(-op = 'cn')
 								#output_temp -> insert(#field = #onevalue )
 							else
 								#output_temp -> insert(-op = 'bw')
 								#output_temp -> insert(#field = #onevalue )
-								if( !.'database' -> 'isfilemaker')
-								// this variant is not needed for FileMaker since it already searches with "word begins with" as default							#output_temp -> (insert:  -op = 'cn');
-									iterate(#wordseparators) => {
+								if( !.database -> 'isfilemaker') => {
+								// this variant is not needed for FileMaker since it already searches with "word begins with" as default							#output_temp -> (insert:  -op = 'cn')
+									with val in #wordseparators do {
 										#output_temp -> insert(-op = 'cn')
-										#output_temp -> insert( #field = loop_value + #onevalue )
+										#output_temp -> insert( #field = #val + #onevalue )
 									}
-								/if
-							/if
-						/if
-					/iterate
-					if(#_sql)
-						if(#output_temp -> size > 1)
-							#output_temp = ('(' + #output_temp -> join( ' OR ') + ')')
+								}
+							}
+						}
+					}
+					if(#_sql) => {
+						if(#output_temp -> size > 1) => {
+							#output_temp = ('(' + #output_temp -> join(' OR ') + ')')
 						else
 							#output_temp = #output_temp -> first
-						/if
+						}
 						#output -> insert(#output_temp)
 					else
-						if(#output_temp -> size > 2)
+						if(#output_temp -> size > 2) => {
 							#output_temp -> insert(-opbegin = 'or', 1)
 							#output_temp -> insert(-opend = 'or')
-						/if;
+						}
 						#output -> merge(#output_temp)
-					/if
-				/iterate
+					}
+				}
 
-				if(#_sql)
-					if(#output -> size > 0)
+				if(#_sql) => {
+					if(#output -> size > 0) => {
 						#output = ('(' + #output -> join(' AND ') + ')')
 					else
 						#output = string
-					/if
+					}
 				else
-					if(#output -> size > 0)
+					if(#output -> size > 0) => {
 						#output -> insert(-opbegin = 'and', 1)
 						#output -> insert(-opend = 'and')
-					/if
-				/if
+					}
+				}
 
-			/if // isfilemaker
-		/if // #fieldvalue != ''
+			} // isfilemaker
+		} // #fieldvalue != ''
+
 
 		return #output
 	}
@@ -538,53 +548,54 @@ Returns all get params that begin with - as a query string, for internal use in 
 			-prefix (optional) For example ? or &amp; to include at the beginning of the querystring
 			-suffix (optional) For example &amp; to include at the end of the querystring
 **/
-	public urlargs(except = '', prefix = '', suffix = '') => {
+	public urlargs(except = string, prefix = string, suffix = string) => {
+
 
 		#except = #except -> ascopy
 
-		local('output' = array)
-		local('param' = null)
+		local(output = array)
+		local(param = null)
 
 		// only getparams to not send along -action etc
-		local('clientparams' = client_getparams -> asarray)
+		local(clientparams = client_getparams -> asarray)
 
 		#except -> type != 'array' ? #except = array(#except)
 		#except -> insert(-session)
 
 		// add getparams that begin with -
-		iterate(#clientparams, #param)
-			if(#param -> type == 'pair')
-				if(#param -> name -> beginswith('-') && #except !>> #param -> name)
+		with param in #clientparams do {
+			if(#param -> isa(::pair)) => {
+				if(#param -> name -> beginswith('-') && #except !>> #param -> name) => {
 					#output -> insert(encode_stricturl(string(#param -> name)) + '=' + encode_stricturl(string(#param -> value)))
-				/if
+				}
 			else // just a string param (no pair)
-				if(#param -> beginswith('-') && #except !>> #param)
+				if(#param -> beginswith('-') && #except !>> #param) => {
 					#output -> insert(encode_stricturl(string(#param)))
-				/if
-			/if
-		/iterate
+				}
+			}
+		}
 
-		if(.'nav' -> isa('knop_nav'))
+		if(.nav -> isa(::knop_nav)) => {
 			// send params that have been defined as -params in nav
-			local('navitem' = .'nav' -> getnav)
+			local(navitem = .nav -> getnav)
 			// add post params
 			#clientparams -> merge(client_postparams)
 
-			iterate(#navitem -> find('params'), #param)
-				if(#clientparams >> #param && #clientparams -> find(#param) -> first -> type == 'pair')
+			with param in #navitem -> find('params') do {
+				if(#clientparams >> #param && #clientparams -> find(#param) -> first -> isa(::pair)) => {
 					#output -> insert(encode_stricturl(string(#clientparams -> find(#param) -> first -> name)) + '=' + encode_stricturl(string(#clientparams -> find(#param) -> first -> value)))
 				else(#clientparams >> #param)
 					#output -> insert(encode_stricturl(string(#clientparams -> find(#param) -> first)))
-				/if
-			/iterate
-		/if
+				}
+			}
+		}
 		#output = string(#output -> join('&amp;'))
 		// restore / in paths
 		#output -> replace('%2F', '/')
 
-		if(#output -> size > 0)
+		if(#output -> size > 0) => {
 			return(#prefix + #output + #suffix)
-		/if
+		}
 	}
 
 /**!
@@ -595,31 +606,45 @@ Outputs the complete record listing. Calls renderheader, renderlisting and rende
 			-inlinename (optional) If not specified, inlinename from the connected database object is used\n\
 			-numbered (optional flag or integer) If specified, pagination links will be shown as page numbers instead of regular prev/next links. Defaults to 6 links, specify another number (minimum 6) if more numbers are wanted.
 **/
-	public renderhtml(inlinename = '', xhtml::boolean = false, numbered::any = false, startwithfooter::boolean = false) => {
+	public renderhtml(
+		inlinename = string,
+		xhtml::boolean = false,
+		numbered::any = false,
+		startwithfooter::boolean = false,
+		bootstrap::boolean = false
+	) => {
 
-		local('output' = string)
-		local('db' = .'database')
 
-		if(#numbered)
-			local('numberedpaging' = (#numbered !== false ? integer(#numbered) | false))
+		local(output = string)
+		local(db = .database)
+
+		if(#numbered) => {
+			local(numberedpaging = (#numbered !== false ? integer(#numbered) | false))
 		else
-			local('numberedpaging' = (.'numbered' !== false ? integer(.'numbered') | false))
-		/if
+			local(numberedpaging = (.numbered !== false ? integer(.numbered) | false))
+		}
 
-		.'footer' = .renderfooter(false, #numberedpaging, #xhtml )
+		.footer = .renderfooter(false, #numberedpaging, #xhtml )
 
-		#output += .renderheader(true, #xhtml, #startwithfooter)
+		#output -> append( .renderheader(true, #xhtml, #startwithfooter, #bootstrap))
 
-		#db -> shown_count >= 10 && !#startwithfooter ? #output += .'footer'
+		#db -> shown_count >= 10 && !#startwithfooter ? #output -> append( .footer)
 
-		#output += (.renderlisting(#inlinename, #xhtml))
+		#output -> append(.renderlisting(#inlinename, #xhtml))
 
-		#output += (.'footer' + '</table>\n')
+		#output -> append(.footer + '</table>\n')
+
 
 		return #output
 	}
 
-	public renderhtml(-inlinename = '', -xhtml::boolean = false, -numbered::any = false, -startwithfooter::boolean = false) => .renderhtml(#inlinename, #xhtml, #numbered, #startwithfooter)
+	public renderhtml(
+		-inlinename = string,
+		-xhtml::boolean = false,
+		-numbered::any = false,
+		-startwithfooter::boolean = false,
+		-bootstrap::boolean = false
+	) => .renderhtml(#inlinename, #xhtml, #numbered, #startwithfooter, #bootstrap)
 
 /**!
 renderlisting
@@ -627,36 +652,40 @@ Outputs just the actual record listing. Is called by renderhtml. \
 			Parameters:\n\
 			-inlinename (optional) If not specified, inlinename from the connected database object is used
 **/
-	public renderlisting(inlinename = '', xhtml::boolean = false) => {
+	public renderlisting(
+		inlinename = string,
+		xhtml::boolean = false
+	) => {
 
-		local('_inlinename' = string)
-		local('output' = string)
-		local('fields' = .'fields')
-		local('field' = string)
-		local('keyfield' = null)
-		local('affectedrecord_keyvalue' = null)
-		local('record_loop_count' = integer)
-		local('db' = .'database')
-		local('nav' = .'nav')
-		local('dbfieldmap' = .'dbfieldmap')
-		local('classarray' = array)
-		local('fieldname' = string)
-		local('value' = string)
-		local('keyparamname')
-		local('url')
-		local('url_cached_temp')
-		local('lang' = .'lang')
 
-		if(#inlinename -> size > 0)
+		local(_inlinename = string)
+		local(output = string)
+		local(fields = .fields)
+		local(field = string)
+		local(keyfield = null)
+		local(affectedrecord_keyvalue = null)
+		local(record_loop_count = integer)
+		local(db = .database)
+		local(nav = .nav)
+		local(dbfieldmap = .dbfieldmap)
+		local(classarray = array)
+		local(fieldname = string)
+		local(value = string)
+		local(keyparamname)
+		local(url)
+		local(url_cached_temp)
+		local(lang = .lang)
+
+		if(#inlinename -> size > 0) => {
 			#_inlinename = #inlinename
-		else(#db -> type == 'knop_database')
+		else(#db -> isa(::knop_database))
 			#_inlinename = #db -> 'inlinename'
 			#keyfield = #db -> 'keyfield'
 			#affectedrecord_keyvalue = #db -> 'affectedrecord_keyvalue'
-		/if
-		#output += '\n<tbody>\n'
-		if(#nav -> isa('knop_nav'))
-			iterate(#fields, #field)
+		}
+		#output -> append( '\n<tbody>\n')
+		if(#nav -> isa('knop_nav')) => {
+			with field in #fields do {
 				if(#field -> find('url') != void) => {
 					#url = string(#field -> find('url'))
 					#keyparamname = #field -> find('keyparamname')
@@ -670,78 +699,79 @@ Outputs just the actual record listing. Is called by renderhtml. \
 				else
 					#url = string
 				}
-			/iterate
-		/if
+			}
+		}
 
 		records(-inlinename = #_inlinename) => {
 			#record_loop_count = loop_count
 
-			#output += '\n<tr' + (.'rowsorting' ? ' class="rowsortable" ref="' + string(field(#keyfield)) + '"') + '>'
-			iterate(#fields, #field)
+			#output -> append( '\n<tr' + (.rowsorting ? ' class="rowsortable" ref="' + string(field(#keyfield)) + '"') + '>')
+			with field in #fields do {
 				#fieldname = #dbfieldmap -> find(#field -> find('name'))
 				#keyparamname = #field -> find('keyparamname')
 				#value = field(#fieldname)
-				if(#field -> find('template') -> type == 'map')
-					#value = string(#value)
-					if(#field -> find('template') >> #value)
-						#value = #field -> find('template') -> find(#value)
-					else(#field -> find('template') >> '-default')
-						#value = #field -> find('template') -> find('-default')
-					else
-						// show fieldvalue as is
-					/if
-					// substitute field value in the display template
-					#value -> replace('#value#', string(field(#fieldname)))
-				else(#field -> find('template') -> isa('tag'))
-					#value = #field -> find('template') -> run(-params = #value)
-				else(#field -> find('template') -> isa('capture'))
-					#value = #field -> find('template') -> detach( )->invoke( )
-//					#value = #field -> find('template') -> run(#value)
-				/if
+				match(#field -> find('template') -> type) => {
+					case(::capture)
+						#value = #field -> find('template') -> detach( )->invoke( )
+					case(::map)
+						#value = string(#value)
+						if(#field -> find('template') >> #value) => {
+							#value = #field -> find('template') -> find(#value)
+						else(#field -> find('template') >> '-default')
+							#value = #field -> find('template') -> find('-default')
+						else
+							// show fieldvalue as is
+						}
+						// substitute field value in the display template
+						#value -> replace('#value#', string(field(#fieldname)))
+					case(::tag)
+						#value = #field -> find('template') -> run(-params = #value)
+				}
 				#classarray = array
-				if(#affectedrecord_keyvalue == field(#keyfield) && field(#keyfield) != '')
+				if(#affectedrecord_keyvalue == field(#keyfield) && field(#keyfield) != '') => {
 					// hightlight affected row
 					#classarray -> insert('highlight')
 				else
 					(#record_loop_count - 1)  % 2 == 0 ? #classarray -> insert('even')
-				/if
+				}
 				// Added by JC 081127 to handle td specific classes
 				#field -> find('class') -> size ? #classarray -> insert( #field -> find('class'))
-				#output += '<td'
-				if(#classarray -> size)
-					#output += (' class="' + #classarray -> join(' ') + '"')
-				/if
-				if(#field -> find('raw') -> size) => {
-					#output += (' ' + #field -> find('raw'))
+				#output -> append( '<td')
+				if(#classarray -> size) => {
+					#output -> append(' class="' + #classarray -> join(' ') + '"')
 				}
-				#output += '>'
-				if(#field -> find('url') != void)
+				if(#field -> find('raw') -> size) => {
+					#output -> append(' ' + #field -> find('raw'))
+				}
+				#output -> append( '>')
+				if(#field -> find('url') != void) => {
 					#url = string(#field -> find('url'))
-stdoutnl('grid field url ' + #field -> find('url_cached'))
-					if(#field -> find('url_cached') -> size > 0 && #url !>> '#value#')
+
+					if(#field -> find('url_cached') -> size > 0 && #url !>> '#value#') => {
 						#url_cached_temp = #field -> find('url_cached') -> ascopy
 						#url_cached_temp -> replace('###keyvalue###', string(field(#keyfield)))
-						#output += ('<a href="' + #url_cached_temp)
-						#output += ('">' +  #value
+						#output -> append('<a href="' + #url_cached_temp)
+						#output -> append('">' +  #value
 							// show something to click on even if the field is empty
 							+ (string_findregexp(#value, -find = '\\w*') -> size == 0 ? #lang -> getstring('linktext_edit'))
 							+ '</a>')
 					else
 						#url -> replace('#value#', string(field(#fieldname)))
-						#output += ('<a href="' + #url + '"')
-						#url -> beginswith('http://') || #url -> beginswith('https://') || #url -> beginswith('mailto:') ? #output += ' class="ext"'
-						#output += ('>' +  #value + '</a>')
-					/if
+						#output -> append('<a href="' + #url + '"')
+						#url -> beginswith('http://') || #url -> beginswith('https://') || #url -> beginswith('mailto:') ? #output -> append(' class="ext"')
+						#output -> append('>' +  #value + '</a>')
+					}
 				else
-					#output += #value
-				/if
-				#output += '</td>\n'
-			/iterate
-			#output += '</tr>\n'
+					#output -> append( #value)
+				}
+				#output -> append( '</td>\n')
+			}
+			#output -> append( '</tr>\n')
 
 		}
 
-		#output += '\n</tbody>\n'
+		#output -> append( '\n</tbody>\n')
+
 
 		return #output
 	}
@@ -753,101 +783,107 @@ Outputs the header of the grid with the column headings. \
 			Parameters:\n\
 			-start (optional flag) Also output opening <table> tag
 **/
-	public renderheader(start::boolean = false, xhtml::boolean = false, startwithfooter::boolean = false) => {
+	public renderheader(start::boolean = false, xhtml::boolean = false, startwithfooter::boolean = false, bootstrap::boolean = false) => {
 
-		local('output' = string)
-		local('db' = .'database')
-		local('nav' = .'nav')
-		local('fields' = .'fields')
-		local('field' = string)
-		local('classarray' = array)
-		local('lang' = .'lang')
 
-		#start ? #output += ('<table id="' + .'tbl_id' + '" class="grid' + (.'class' -> size > 0 ? (' ' + .'class')) + '">')
-		#output += '<thead>\n<tr>'
-		if(.'quicksearch_form' -> type == 'knop_form')
-			#output += ('<th colspan="' + #fields -> size + '" class="quicksearch')
-			.'quicksearch_form' -> getvalue('-q') != '' ? #output += ' highlight'
-			#output += '">'
+		local(output = string)
+		local(db = .database)
+		local(nav = .nav)
+		local(fields = .fields)
+		local(field = string)
+		local(classarray = array)
+		local(lang = .lang)
 
-			if(.'rawheader' -> size > 0 )
-				#output += .'rawheader'
-			/if
+		#start ? #output -> append('<table id="' + .tbl_id + '" class="grid' + (.class -> size > 0 ? (' ' + .class)) + '">')
+		#output -> append('<thead>\n<tr>')
+		if(.quicksearch_form -> isa(::knop_form)) => {
+			#output -> append('<th colspan="' + #fields -> size + '" class="quicksearch')
+			.quicksearch_form -> getvalue('-q') != '' ? #output -> append( ' highlight')
+			#output -> append( '">')
 
-			#output += .'quicksearch_form' -> renderform(-xhtml = #xhtml)
-			if(.'quicksearch_form_reset' -> type == 'knop_form')
-				#output += .'quicksearch_form_reset' -> renderform(-xhtml = #xhtml)
-			/if
-			#output += '</th></tr>\n<tr>'
-		else(.'rawheader' -> size > 0);
-			#output += ('<th colspan="' + (#fields -> size) + '">' + .'rawheader' + '</th></tr>\n<tr>')
-		/if
+			if(.rawheader -> size > 0 ) => {
+				#output -> append( .rawheader)
+			}
+			#output -> append( .quicksearch_form -> renderform(-xhtml = #xhtml, -bootstrap = #bootstrap))
+			if(.quicksearch_form_reset -> isa(::knop_form)) => {
+				#output -> append( .quicksearch_form_reset -> renderform(-xhtml = #xhtml, -bootstrap = #bootstrap))
+			}
+			#output -> append( '</th></tr>\n<tr>')
+		else(.rawheader -> size > 0)
+			#output -> append('<th colspan="' + (#fields -> size) + '">' + .rawheader + '</th></tr>\n<tr>')
+		}
 
-		if(#startwithfooter);
-			#output += .'footer'
-		/if;
+		if(#startwithfooter) => {
+			#output -> append( .footer)
+		}
 
-		iterate(#fields, #field)
+		with field in #fields do {
 			#classarray = array
-			//(.'quicksearch_form') -> type == 'knop_form' ? #classarray -> (insert: 'notopborder');
-			if(!.'nosort')
-				(.'sortfield' == #field -> find('name')
+			//(.quicksearch_form) -> isa(::knop_form) ? #classarray -> (insert: 'notopborder')
+			if(!.nosort) => {
+				(.sortfield == #field -> find('name')
 					&& !#field -> find('nosort')) ? #classarray -> insert('sort')
-			/if
-			#output += '<th'
-			if(#field -> find('width') > 0)
-				#output += (' style="width: ' + integer(#field -> find('width')) + 'px;"')
-			/if
+			}
+			#output -> append( '<th')
+			if(#field -> find('width') > 0) => {
+				#output -> append(' style="width: ' + integer(#field -> find('width')) + 'px;"')
+			}
 			// Added by Jolle 081127 to handle td specific classes
 			#field -> find('class') -> size > 0 ? #classarray -> insert( #field -> find('class'))
-			#classarray -> size > 0 ? #output += (' class="' + #classarray -> join(' ') + '"')
+			#classarray -> size > 0 ? #output -> append(' class="' + #classarray -> join(' ') + '"')
 
-			#output += '>'
-			if(#field -> find('nosort') || .'nosort')
-				#output += ('<div>' + #field -> find('label')+ '</div>')
+			#output -> append( '>')
+			if(#field -> find('nosort') || .nosort) => {
+				#output -> append('<div>' + #field -> find('label')+ '</div>')
 			else
-				if(#classarray >> 'sort' && .'sortdescending' && .'defaultsort' == '')
+				if(#classarray >> 'sort' && .sortdescending && .defaultsort == '') => {
 					// create link to change to unsorted
-					if(#nav -> isa('knop_nav'))
-						#output += ('<a href="' + #nav -> url(-autoparams, -getargs, -except = array('-sort', '-desc', '-page', '-path')) + '"'
+					if(#nav -> isa(::knop_nav)) => {
+						#output -> append('<a href="' + #nav -> url(-autoparams, -getargs, -except = array('-sort', '-desc', '-page', '-path')) + '"'
 							+ ' title="' + #lang -> getstring('linktitle_showunsorted') + '">')
 					else
-						#output += ('<a href="./'
+						#output -> append('<a href="./'
 							+ .urlargs(-except = array('-sort', '-desc', '-page'), -prefix = '?') + '"'
 							+ ' title="' + #lang -> getstring('linktitle_showunsorted') + '">')
-					/if
+					}
 				else
 					// create link to toggle sort mode
-					if(#nav -> isa('knop_nav'))
-						#output += ('<a href="' + #nav -> url(-autoparams, -getargs, -except = array('-sort', '-desc', '-page', '-path'), -urlargs = ('-sort=' + #field -> find('name')
-								+ (#classarray >> 'sort' && !(.'sortdescending') ? '&amp;-desc'))) + '"'+ ' title="'
+					if(#nav -> isa('knop_nav')) => {
+						#output -> append('<a href="' + #nav -> url(-autoparams, -getargs, -except = array('-sort', '-desc', '-page', '-path'), -urlargs = ('-sort=' + #field -> find('name')
+								+ (#classarray >> 'sort' && !(.sortdescending) ? '&amp;-desc'))) + '"'+ ' title="'
 								+ (#classarray >> 'sort' ?  (#lang -> getstring('linktitle_changesort') + ' '
-									+ (.'sortdescending' ? #lang -> getstring('linktitle_ascending') | #lang -> getstring('linktitle_descending')) ) | (#lang -> getstring('linktitle_sortascby') + ' ' + encode_html(#field -> find('label'))) ) + '">')
+									+ (.sortdescending ? #lang -> getstring('linktitle_ascending') | #lang -> getstring('linktitle_descending')) ) | (#lang -> getstring('linktitle_sortascby') + ' ' + encode_html(#field -> find('label'))) ) + '">')
 					else
-						#output += ('<a href="./?-sort=' + #field -> find('name')
-							+ (#classarray >> 'sort' && !(.'sortdescending') ? '&amp;-desc')
+						#output -> append('<a href="./?-sort=' + #field -> find('name')
+							+ (#classarray >> 'sort' && !(.sortdescending) ? '&amp;-desc')
 							+ .urlargs(-except = array('-sort', '-desc', '-page'), -prefix = '&amp;') + '"'
 							+ ' title="' + (#classarray >> 'sort' ?  (#lang -> getstring('linktitle_changesort') + ' '
-									+ (.'sortdescending' ? #lang -> getstring('linktitle_ascending') | #lang -> getstring('linktitle_descending'))) | (#lang -> getstring('linktitle_sortascby') + ' ' + encode_html(#field -> find('label'))) ) + '">')
-					/if
-				/if
-				#output += #field -> find('label')
-				if(string_findregexp(#field -> find('label'), -find = '\\S') -> size == 0)
-					#output += '&nbsp;' // to show sort link as block element properly even for empty label
-				/if
-				if(#classarray >> 'sort')
-					#output += (' <span class="sortmarker"> ' + (.'sortdescending' ? '&#9660;' | '&#9650;') + '</span>')
-				/if
-				#output += '</a>'
-			 /if
-			 #output += '</th>\n'
-		/iterate
-		#output += '</tr>\n</thead>\n'
+									+ (.sortdescending ? #lang -> getstring('linktitle_ascending') | #lang -> getstring('linktitle_descending'))) | (#lang -> getstring('linktitle_sortascby') + ' ' + encode_html(#field -> find('label'))) ) + '">')
+					}
+				}
+				#output -> append( #field -> find('label'))
+				if(string_findregexp(#field -> find('label'), -find = '\\S') -> size == 0) => {
+					#output -> append( '&nbsp;') // to show sort link as block element properly even for empty label
+				}
+				if(#classarray >> 'sort') => {
+					#output -> append(' <span class="sortmarker"> ' + (.sortdescending ? '&#9660;' | '&#9650;') + '</span>')
+				}
+				#output -> append( '</a>')
+			 }
+			 #output -> append( '</th>\n')
+		}
+		#output -> append( '</tr>\n</thead>\n')
+
 
 		return #output
 	}
 
-	public renderheader(-start::boolean = false, -xhtml::boolean = false, -startwithfooter::boolean = false) => .renderheader(#start, #xhtml, #startwithfooter)
+	public renderheader(
+		-start::boolean = false,
+		-xhtml::boolean = false,
+		-startwithfooter::boolean = false,
+		-bootstrap::boolean = false
+	) => .renderheader(#start, #xhtml, #startwithfooter, #bootstrap)
 
 /**!
 renderfooter
@@ -859,234 +895,203 @@ Outputs the footer of the grid with the prev/next links and information about fo
 **/
 	public renderfooter(end::boolean = false, numbered::any = false, xhtml::boolean = false) => {
 
-		local('output' = string)
-		local('db' = .'database')
-		local('nav' = .'nav')
-		local('fields' = .'fields')
-		local('field' = string)
-			//'numberedpaging' = (((local_defined: 'numbered') && #numbered !== false) ? integer(#numbered) | false),
-		local('lang' = .'lang')
-		local('page' = .page)
-		local('lastpage' = .lastpage)
-		local('url_cached')
-		local('url_cached_temp')
-		if(#numbered)
-			local('numberedpaging' = (#numbered !== false ? integer(#numbered) | false))
-		else
-			local('numberedpaging' = (.'numbered' !== false ? integer(.'numbered') | false))
-		/if
 
-		if(#nav -> isa('knop_nav'))
+		local(output = string)
+		local(db = .database)
+		local(nav = .nav)
+		local(fields = .fields)
+			//'numberedpaging' = (((local_defined: 'numbered') && #numbered !== false) ? integer(#numbered) | false),
+		local(lang = .'lang')
+		local(page = .page)
+		local(lastpage = .lastpage)
+		local(url_cached)
+		local(url_cached_temp)
+		if(#numbered) => {
+			local(numberedpaging = (#numbered !== false ? integer(#numbered) | false))
+		else
+			local(numberedpaging = (.numbered !== false ? integer(.numbered) | false))
+		}
+
+		if(#nav -> isa(::knop_nav)) => {
 			#url_cached = #nav -> url(-autoparams, -getargs, -except = array('-page', '-path'),
 					-urlargs = '-page=###page###')
-		/if
-		if(#numberedpaging !== false && #numberedpaging < 6)
+		}
+		if(#numberedpaging !== false && #numberedpaging < 6) => {
 			// show 10 page numbers as default
 			#numberedpaging = 6
-		/if
-		if(#numberedpaging)
+		}
+		if(#numberedpaging) => {
 			// make sure we have an even number
 			#numberedpaging += (#numberedpaging % 2)
-		/if
+		}
 
-		#output += ('<tbody>\n<tr><th colspan="' + #fields -> size + '" class="footer first'  + '">')
-		/* not used
-		if: #nav -> isa('knop_nav');
-			local: 'url' = #nav -> url(-autoparams, -getargs, -except = (array: -page, '-path'), -urlargs = '-page='),
-				'url_prefix' = (#nav -> 'navmethod' == 'param' ? '&amp;' | '?');
-		else;
-			local: 'url' = './' + (.(urlargs: -except = (array: -page, '-path'), -suffix = '&amp;')),
-				'url_prefix' = '?';
-		/if;
-		*/
+		#output -> append('<tbody>\n<tr><th colspan="' + #fields -> size + '" class="footer first'  + '">')
 
-		if(#numberedpaging)
-			local('page_from' = 1)
-			local('page_to' = #lastpage)
-			if(#lastpage > #numberedpaging)
+
+		if(#numberedpaging) => {
+
+			local(page_from = 1)
+			local(page_to = #lastpage)
+			if(#lastpage > #numberedpaging) => {
 				#page_from = (#page - (#numberedpaging/2 - 1))
 				#page_to = (#page + (#numberedpaging/2))
-				if(#page_from < 1)
+				if(#page_from < 1) => {
 					#page_to += (1 - #page_from)
 					#page_from = 1
-				/if
-				if(#page_to > #lastpage)
+				}
+				if(#page_to > #lastpage) => {
 					#page_from = (#lastpage - (#numberedpaging - 1))
 					#page_to = #lastpage
-				/if
-			/if
+				}
+			}
 
-			#output += ('<span class="foundcount">' + #db -> found_count + ' ' + (#lang -> getstring('footer_found')) + '</span> <span class="pagination">')
+			#output -> append('<span class="foundcount">' + #db -> found_count + ' ' + (#lang -> getstring('footer_found')) + '</span> <span class="pagination">')
 
-			if(#page > 1)
-				if(#url_cached -> size > 0)
+			if(#page > 1) => {
+				if(#url_cached -> size > 0) => {
 					#url_cached_temp = #url_cached -> ascopy
 // old					#url_cached_temp -> replace('-page = ###page###', '-page = ' + (#page - 1))
-					#url_cached_temp -> replace('-page=###page###', '-page=' + 1);
+					#url_cached_temp -> replace('-page=###page###', '-page=' + 1)
 
-					/*#output += ' <a href="' + #nav -> url(-autoparams, -getargs, -except = (array: -page, '-path'),
-						-urlargs = '-page = ' + (#page - 1)) + '" class="prevnext prev"'
-						+ ' title="' + (#lang -> getstring('linktitle_goprev')) + '">' + (#lang -> getstring('linktext_prev')) + '</a> ';*/
-					#output += (' <a href="' + #url_cached_temp + '" class="prevnext first"'
+					#output -> append(' <a href="' + #url_cached_temp + '" class="prevnext first"'
 						+ ' title="' + (#lang -> getstring('linktitle_gofirst')) + '">' + (#lang -> getstring('linktext_first')) + '</a> ')
 
 					#url_cached_temp = #url_cached -> ascopy
-					#url_cached_temp -> replace('-page=###page###', '-page=' + (#page - 1));
-					#output += (' <a href="' + #url_cached_temp + '" class="prevnext prev"'
+					#url_cached_temp -> replace('-page=###page###', '-page=' + (#page - 1))
+					#output -> append(' <a href="' + #url_cached_temp + '" class="prevnext prev"'
 						+ ' title="' + #lang -> getstring('linktitle_goprev') + '">' + #lang -> getstring('linktext_prev') + '</a> ')
 				else
-					#output += (' <a href="./?' + .urlargs(-except = array('-page', '-path'), -suffix = '&amp;') + '-page=1" class="prevnext first"'
+					#output -> append(' <a href="./?' + .urlargs(-except = array('-page', '-path'), -suffix = '&amp;') + '-page=1" class="prevnext first"'
 						+ ' title="' + (#lang -> getstring('linktitle_gofirst')) + '">' + (#lang -> getstring('linktext_first')) + '</a> ')
-					#output += (' <a href="./?' + (.urlargs( -except = array('-page', '-path'), -suffix = '&amp;')) + '-page=' + (#page - 1) + '" class="prevnext prev"' + ' title="' + #lang -> getstring('linktitle_goprev') + '">' + #lang -> getstring('linktext_prev') + '</a> ')
-				/if
-			else
-				//#output += ' <span class="prevnext prev dim">' + (#lang -> getstring('linktext_prev')) + '</span> ';
-			/if
-			if(#page_from > 1)
-				if(#url_cached -> size > 0)
+					#output -> append(' <a href="./?' + (.urlargs( -except = array('-page', '-path'), -suffix = '&amp;')) + '-page=' + (#page - 1) + '" class="prevnext prev"' + ' title="' + #lang -> getstring('linktitle_goprev') + '">' + #lang -> getstring('linktext_prev') + '</a> ')
+				}
+			}
+			if(#page_from > 1) => {
+				if(#url_cached -> size > 0) => {
 					#url_cached_temp = #url_cached -> ascopy
 					#url_cached_temp -> replace('-page=###page###', '-page=' + 1)
-					/*#output += ' <a href="' + #nav -> url(-autoparams, -getargs, -except = (array: -page, '-path'),
-						-urlargs = '-page=1') + '" class="prevnext numbered first">1</a>';*/
-					#output += (' <a href="' + #url_cached_temp + '" class="prevnext numbered first">1</a>')
+					#output -> append(' <a href="' + #url_cached_temp + '" class="prevnext numbered first">1</a>')
 				else
-					#output += (' <a href="./?' + .urlargs(-except = array('-page', '-path'), -suffix = '&amp;') + '-page=1" class="prevnext numbered first">1</a> ')
-				/if
-				#page_from > 2 ? #output +='...'
+					#output -> append(' <a href="./?' + .urlargs(-except = array('-page', '-path'), -suffix = '&amp;') + '-page=1" class="prevnext numbered first">1</a> ')
+				}
+				#page_from > 2 ? #output -> append('...')
 
-			/if
+			}
 			loop(-from = #page_from, -to = #page_to)
-				if(loop_count == #page)
-					#output += (' <span class="numbered current">' + loop_count + '</span> ')
+				if(loop_count == #page) => {
+					#output -> append(' <span class="numbered current">' + loop_count + '</span> ')
 				else
-					if(#url_cached -> size > 0)
+					if(#url_cached -> size > 0) => {
 						#url_cached_temp = #url_cached -> ascopy
 						#url_cached_temp -> replace('-page=###page###', '-page=' + loop_count)
-						/*#output += ' <a href="' + #nav -> url(-autoparams, -getargs, -except=(array: -page, '-path'),
-							-urlargs='-page=' + loop_count) + '" class="prevnext numbered">' + loop_count + '</a> ';*/
-						#output += (' <a href="' + #url_cached_temp + '" class="prevnext numbered">' + loop_count + '</a> ')
+						#output -> append(' <a href="' + #url_cached_temp + '" class="prevnext numbered">' + loop_count + '</a> ')
 					else
-						#output += (' <a href="./?' + .urlargs(-except = array('-page', '-path'), -suffix = '&amp;') + '-page=' + loop_count + '" class="prevnext numbered">' + loop_count + '</a> ')
-					/if
-				/if
+						#output -> append(' <a href="./?' + .urlargs(-except = array('-page', '-path'), -suffix = '&amp;') + '-page=' + loop_count + '" class="prevnext numbered">' + loop_count + '</a> ')
+					}
+				}
 			/loop
-			if(#page_to < #lastpage)
-				#page_to < (#lastpage - 1) ? #output += '...';
+			if(#page_to < #lastpage) => {
+				#page_to < (#lastpage - 1) ? #output -> append('...')
 
-				if(#url_cached -> size > 0)
+				if(#url_cached -> size > 0) => {
 					#url_cached_temp = #url_cached -> ascopy
 					#url_cached_temp -> replace('-page=###page###', '-page=' + #lastpage)
-					/*#output += ' <a href="' + #nav -> url(-autoparams, -getargs, -except = (array: -page, '-path'),
-						-urlargs = '-page=' + #lastpage) + '" class="prevnext numbered last">' + #lastpage + '</a> ';*/
-					#output += (' <a href="' + #url_cached_temp + '" class="prevnext numbered last">' + #lastpage + '</a> ')
+					#output -> append(' <a href="' + #url_cached_temp + '" class="prevnext numbered last">' + #lastpage + '</a> ')
 				else
-					#output += (' <a href="./?' + .urlargs(-except = array('-page', '-path'), -suffix = '&amp;') + '-page=' + #lastpage + '" class="prevnext numbered last">' + #lastpage + '</a> ')
-				/if
-			/if
+					#output -> append(' <a href="./?' + .urlargs(-except = array('-page', '-path'), -suffix = '&amp;') + '-page=' + #lastpage + '" class="prevnext numbered last">' + #lastpage + '</a> ')
+				}
+			}
 
-			if( #page < #lastpage)
-				if(#url_cached -> size > 0)
+			if( #page < #lastpage) => {
+				if(#url_cached -> size > 0) => {
 					#url_cached_temp = #url_cached -> ascopy
 					#url_cached_temp -> replace('-page=###page###', '-page=' + (#page + 1))
-					/*#output += ' <a href="' + #nav -> url(-autoparams, -getargs, -except=(array: -page, '-path'),
-						-urlargs='-page=' + (#page + 1)) + '" class="prevnext next"'
-						+ ' title="' + (#lang -> getstring('linktitle_gonext')) + '">' + (#lang -> getstring('linktext_next')) + '</a> ';*/
-					#output += (' <a href="' + #url_cached_temp + '" class="prevnext next"'
+					#output -> append(' <a href="' + #url_cached_temp + '" class="prevnext next"'
 						+ ' title="' + #lang -> getstring('linktitle_gonext') + '">' + #lang -> getstring('linktext_next') + '</a> ')
 
 					#url_cached_temp = #url_cached -> ascopy
-					#url_cached_temp -> replace('-page=###page###', '-page=' + #lastpage);
-					#output += (' <a href="' + #url_cached_temp + '" class="prevnext last"'
+					#url_cached_temp -> replace('-page=###page###', '-page=' + #lastpage)
+					#output -> append(' <a href="' + #url_cached_temp + '" class="prevnext last"'
 						+ ' title="' + (#lang -> getstring('linktitle_golast')) + '">' + (#lang -> getstring('linktext_last')) + '</a> ')
 				else
-					#output += (' <a href="./?' + .urlargs(-except = array('-page', '-path'), -suffix = '&amp;') + '-page=' + (#page + 1) + '" class="prevnext next"'
+					#output -> append(' <a href="./?' + .urlargs(-except = array('-page', '-path'), -suffix = '&amp;') + '-page=' + (#page + 1) + '" class="prevnext next"'
 						+ ' title="' + #lang -> getstring('linktitle_gonext') + '">' + #lang -> getstring('linktext_next') + '</a> ')
-					#output += (' <a href="./?' + (.urlargs( -except = array( '-page', '-path'), -suffix = '&amp;'))
+					#output -> append(' <a href="./?' + (.urlargs( -except = array( '-page', '-path'), -suffix = '&amp;'))
 						+ '-page=' + #lastpage + '" class="prevnext last"'
 						+ ' title="' + (#lang -> getstring('linktitle_golast')) + '">' + (#lang -> getstring('linktext_last')) + '</a> ')
 
-				/if
-			else
-				//#output += ' <span class="prevnext next dim">' + (#lang -> getstring('linktext_next')) + '</span> ';
-			/if
+				}
+			}
 
-			#output += '</span> '
+			#output -> append('</span> ')
+
 
 		else  // regular prev/next links
 
-			if(#page > 1)
-				if(#url_cached -> size > 0)
+
+			if(#page > 1) => {
+				if(#url_cached -> size > 0) => {
 					#url_cached_temp = #url_cached -> ascopy
 					#url_cached_temp -> replace('-page=###page###', '-page=' + 1)
-					/*#output += ' <a href="' + #nav -> url(-autoparams, -getargs, -except=(array: -page, '-path'),
-						-urlargs='-page=1') + '" class="prevnext first"'
-						+ ' title="' + (#lang -> getstring('linktitle_gofirst')) + '">' + (#lang -> getstring('linktext_first')) + '</a> ';*/
-					#output += (' <a href="' + #url_cached_temp + '" class="prevnext first"'
+					#output -> append(' <a href="' + #url_cached_temp + '" class="prevnext first"'
 						+ ' title="' + #lang -> getstring('linktitle_gofirst') + '">' + #lang -> getstring('linktext_first') + '</a> ')
 
 					#url_cached_temp = #url_cached -> ascopy
 					#url_cached_temp -> replace('-page=###page###', '-page=' + (#page - 1))
-					#output += (' <a href="' + #url_cached_temp + '" class="prevnext prev"'
+					#output -> append(' <a href="' + #url_cached_temp + '" class="prevnext prev"'
 						+ ' title="' + #lang -> getstring('linktitle_goprev') + '">' + #lang -> getstring('linktext_prev') + '</a> ')
 				else
-					#output += (' <a href="./?' + .urlargs(-except = array('-page', '-path'), -suffix = '&amp;') + '-page=1" class="prevnext first"'
+					#output -> append(' <a href="./?' + .urlargs(-except = array('-page', '-path'), -suffix = '&amp;') + '-page=1" class="prevnext first"'
 						+ ' title="' + #lang -> getstring('linktitle_gofirst') + '">' + #lang -> getstring('linktext_first') + '</a> ')
 
-					#output += (' <a href="./?' + .urlargs(-except = array('-page', '-path'), -suffix = '&amp;') + '-page=' + (#page - 1) + '" class="prevnext prev"'
+					#output -> append(' <a href="./?' + .urlargs(-except = array('-page', '-path'), -suffix = '&amp;') + '-page=' + (#page - 1) + '" class="prevnext prev"'
 						+ ' title="' + #lang -> getstring('linktitle_goprev') + '">' + #lang -> getstring('linktext_prev') + '</a> ')
-				/if
+				}
 			else
-				#output += (' <span class="prevnext first dim">' + #lang -> getstring('linktext_first') + '</span> \
+				#output -> append(' <span class="prevnext first dim">' + #lang -> getstring('linktext_first') + '</span> \
 							<span class="prevnext prev dim">' + #lang -> getstring('linktext_prev') + '</span> ')
-			/if
+			}
 			#db -> found_count > #db -> shown_count ?
-				#output += (#lang -> getstring('footer_shown', -replace = array(string(#db -> shown_first), string(#db -> shown_last))) + ' ')
-			#output += (#db -> found_count + ' ' + #lang -> getstring('footer_found'))
-			if(#db -> shown_last < #db -> found_count)
-				if(#url_cached -> size > 0)
+				#output -> append(#lang -> getstring('footer_shown', -replace = array(string(#db -> shown_first), string(#db -> shown_last))) + ' ')
+			#output -> append(#db -> found_count + ' ' + #lang -> getstring('footer_found'))
+			if(#db -> shown_last < #db -> found_count) => {
+				if(#url_cached -> size > 0) => {
 					#url_cached_temp = #url_cached -> ascopy
 					#url_cached_temp -> replace('-page=###page###', '-page=' + (#page + 1))
-					/*#output += ' <a href="' + #nav -> url(-autoparams, -getargs, -except=(array: -page, '-path'),
-						-urlargs='-page=' + (#page + 1)) + '" class="prevnext next"'
-						+ ' title="' + (#lang -> getstring('linktitle_gonext')) + '">' + (#lang -> getstring('linktext_next')) + '</a> ';*/
-					#output += (' <a href="' + #url_cached_temp + '" class="prevnext next"'
+					#output -> append(' <a href="' + #url_cached_temp + '" class="prevnext next"'
 						+ ' title="' + #lang -> getstring('linktitle_gonext') + '">' + #lang -> getstring('linktext_next') + '</a> ')
 
 					#url_cached_temp = #url_cached -> ascopy
 					#url_cached_temp -> replace('-page=###page###', '-page=' + #lastpage)
-					#output += (' <a href="' + #url_cached_temp + '" class="prevnext last"'
+					#output -> append(' <a href="' + #url_cached_temp + '" class="prevnext last"'
 						+ ' title="' + #lang -> getstring('linktitle_golast') + '">' + #lang -> getstring('linktext_last') + '</a> ')
 				else
-					#output += (' <a href="./?' + .urlargs(-except = array('-page', '-path'), -suffix = '&amp;') + '-page=' + (#page + 1) + '" class="prevnext next"'
+					#output -> append(' <a href="./?' + .urlargs(-except = array('-page', '-path'), -suffix = '&amp;') + '-page=' + (#page + 1) + '" class="prevnext next"'
 						+ ' title="' + #lang -> getstring('linktitle_gonext') + '">' + #lang -> getstring('linktext_next') + '</a> ')
-					#output += (' <a href="./?' + .urlargs(-except = array('-page', '-path'), -suffix = '&amp;') + '-page=' + .lastpage + '" class="prevnext last"'
+					#output -> append(' <a href="./?' + .urlargs(-except = array('-page', '-path'), -suffix = '&amp;') + '-page=' + .lastpage + '" class="prevnext last"'
 						+ ' title="' + #lang -> getstring('linktitle_golast') + '">' + #lang -> getstring('linktext_last') + '</a> ')
-				/if
+				}
 			else
-				#output += (' <span class="prevnext next dim">' + #lang -> getstring('linktext_next') + '</span>  \
+				#output -> append(' <span class="prevnext next dim">' + #lang -> getstring('linktext_next') + '</span>  \
 							<span class="prevnext last dim">' + #lang -> getstring('linktext_last') + '</span> ')
-			/if
-		/if
-		#output += ('</th></tr>\n</tbody>')
-		#end ? #output += '</table>\n'
+			}
+		}
+		#output -> append('</th></tr>\n</tbody>')
+		#end ? #output -> append( '</table>\n')
+
 
 		return #output
 	}
 
 	public renderfooter(-end::boolean = false, -numbered::any = false, -xhtml::boolean = false) => .renderfooter(#end, #numbered, #xhtml)
 
-	public page() => {
-		local('description' = 'Returns the current page number')
-		return .'page'
-	}
-
 	public lastpage() => {
-		local('description'='Returns the number of the last page for the found records')
-		if(.'database' -> 'found_count' > 0)
-			return (((.'database' -> 'found_count' - 1) / .'database' -> 'maxrecords_value') + 1)
+		local(description = 'Returns the number of the last page for the found records')
+		if(.database -> 'found_count' > 0) => {
+			return (((.database -> 'found_count' - 1) / .database -> 'maxrecords_value') + 1)
 		else
 			return 1
-		/if
+		}
 	}
 
 /**!
@@ -1097,13 +1102,14 @@ Converts current page value to a skiprecords value to use in a search. \n\
 **/
 	public page_skiprecords(maxrecords::integer) => {
 		// TODO: maxrecords_value can be taken from the database object so should not be required
-		return ((.'page' - 1) * #maxrecords)
+		return ((.page - 1) * #maxrecords)
 	}
 
-	public addurlarg(field::string, value = '') => {
-		.'urlparams' -> insert(#value -> size > 0 ? (#field + '=' + #value) | #field)
+	public addurlarg(field::string, value = string) => {
+		.urlparams -> insert(#value -> size > 0 ? (#field + '=' + #value) | #field)
 	}
 
 }
+
 
 ?>

--- a/knop9/knoplibs/knop_lang.lasso
+++ b/knop9/knoplibs/knop_lang.lasso
@@ -13,6 +13,10 @@ define knop_lang => type {
 	/*
 
 	CHANGE NOTES
+	2013-04-02	JC	Add log_critical for keys that wasn't found and if the -always flag is set
+	2013-01-29	JC	Minor cleanup. Should mean an ever so small speed gain.
+	2012-11-04	JC	Added param always to getstring. Will always return a value. If the key is not found will return the keyvalue itself
+	2012-06-10	JC	Changed all iterate to query expr or loop. Removed all semicolons. Changed all old style if to code blocks.
 	2012-05-18	JC	Added additional signature for unknowntag to support keyword calls
 	2012-05-14	JC	Reactivated unknowntag
 	2012-05-14	JC	Added set to allowed params for getstring -replace
@@ -26,13 +30,13 @@ define knop_lang => type {
 
 	*/
 
-	data public version::date = date('2011-06-18') -> format('%Q')
+	data public version::date = date('2013-04-02') -> format('%Q')
 
 	data public strings::map = map
-	data fallback::boolean = false
-	data debug::boolean = false
-	data public defaultlanguage::string = ''
-	data public currentlanguage::string = ''
+	data fallback::boolean
+	data debug::boolean
+	data public defaultlanguage::string
+	data public currentlanguage::string = string
 	data public keys = null
 
 	/**!
@@ -43,18 +47,18 @@ define knop_lang => type {
 	-fallback (optional) If specified, falls back to default language if key is missing.
 	**/
 	public onCreate(
-		default::string = '',
+		default::string = string,
 		fallback::boolean = false,
 		debug::boolean = false
 	) => {
 
-		.'defaultlanguage' = #default;
-		.'fallback' = #fallback;
-		.'debug' = #debug;
+		.'defaultlanguage' = #default
+		.'fallback' = #fallback
+		.'debug' = #debug
 
 	}
 
-	public onCreate(-default::string = '') => .onCreate(#default)
+	public onCreate(-default::string = string) => .onCreate(#default)
 
 	public onConvert() => (self -> listmethods)
 
@@ -67,15 +71,15 @@ define knop_lang => type {
 		-replace (optional) see getstring( -replace).
 	**/
 	public _unknowntag(
-		language::any = '',
-		replace::any = ''
+		language::any = string,
+		replace::any = string
 	) => {
 		local(name = string(currentCapture->calledName))
 		return .keys >> #name ? .getstring(string(#name), string(#language), #replace)
 	}
 	public _unknowntag(
-		-language::any = '',
-		-replace::any = ''
+		-language::any = string,
+		-replace::any = string
 	) => {
 		local(name = string(currentCapture->calledName))
 		return .keys >> #name ? .getstring(string(#name), string(#language), #replace)
@@ -93,8 +97,8 @@ define knop_lang => type {
 		strings::map = map
 	) => {
 
-		.'keys' = null;
-		.'strings' -> insert( #language = #strings);
+		.'keys' = null
+		.'strings' -> insert( #language = #strings)
 	}
 	public addlanguage(
 		-language::string,
@@ -114,10 +118,10 @@ define knop_lang => type {
 		key::string,
 		value::string
 	) => {
-		.'keys' = null;
-		.'strings' !>> #language ? .'strings' -> insert( #language = map);
+		.'keys' = null
+		.'strings' !>> #language ? .'strings' -> insert( #language = map)
 
-		(.'strings' -> find( #language)) -> insert( #key = #value);
+		(.'strings' -> find( #language)) -> insert( #key = #value)
 
 	}
 
@@ -132,116 +136,114 @@ define knop_lang => type {
 	**/
 	public getstring(
 		key::any,
-		language::string = '',
-		replace = ''
+		language::string = string,
+		replace = string,
+		always::boolean = false
 	) => {
 
-		#language = #language -> ascopy;
-		#replace = #replace -> ascopy;
+		#language = #language -> ascopy
+		#replace = #replace -> ascopy
 
-		if(!var_defined('_knop_data'));
+		if(not var_defined('_knop_data')) => {
 			// page level caching
-			var('_knop_data' = map);
-		/if;
+			var(_knop_data = map)
+		}
 
-		local(output = '');
+		local(output = string)
 
-		if(#language -> size == 0 || !(.validlanguage( #language)));
-			#language = .'currentlanguage';
-			if(#language -> size == 0);
-				local(currentlanguage) = $_knop_data -> find( 'currentlanguage');
-				if(.validlanguage( #currentlanguage));
+		if(#language -> size == 0 || !(.validlanguage( #language))) => {
+			#language = .'currentlanguage'
+			if(#language -> size == 0) => {
+				local(currentlanguage) = $_knop_data -> find( 'currentlanguage')
+				if(.validlanguage( #currentlanguage)) => {
 					// fall back to page level language
-					#language = #currentlanguage;
-				else;
+					#language = #currentlanguage
+				else
 					// fall back to the browser's preferred language
-					#language = .browserlanguage;
-				/if;
-			/if;
-			if(#language -> size == 0 && .validlanguage( .'defaultlanguage'));
+					#language = .browserlanguage
+				}
+			}
+			if(#language -> size == 0 && .validlanguage( .'defaultlanguage')) => {
 				// still no matching language, fall back to defaultlanguage
-				#language = .'defaultlanguage';
-			else(#language -> size == 0);
+				#language = .'defaultlanguage'
+			else(#language -> size == 0)
 				// still no matching language, fall back to the first language
-				#language = .'strings' -> keys -> first;
-			/if;
+				#language = .'strings' -> keys -> first
+			}
 			if(.'strings' !>> #language
 				|| (.'strings' >> #language
 					&& .'strings' -> find( #language) !>> #key
-					&& .'fallback'));
+					&& .'fallback')) => {
 				// key is not found in current language, switch to default language
-				if(.validlanguage( .'defaultlanguage'));
+				if(.validlanguage( .'defaultlanguage')) => {
 					// still no matching language, fall back to defaultlanguage
-					#language = .'defaultlanguage';
-				else;
+					#language = .'defaultlanguage'
+				else
 					// no default language to fall back to
-				/if;
-			/if;
-		/if;
-		if(.'strings' >> #language);
-			if(.'strings' -> find(#language) !>> #key);
+				}
+			}
+		}
+		if(.'strings' >> #language) => {
+			if(.'strings' -> find(#language) !>> #key) => {
 				/* pending a debugging feature
-				(self -> 'debug_trace') -> insert('Error: ' + #key + ' not found');
-				self -> 'tagtime_tagname' = tag_name;
-				self -> 'tagtime' = integer(#timer); // cast to integer to trigger onconvert and to "stop timer"
+				(self -> 'debug_trace') -> insert('Error: ' + #key + ' not found')
+				self -> 'tagtime_tagname' = tag_name
+				self -> 'tagtime' = integer(#timer) // cast to integer to trigger onconvert and to "stop timer"
 				(self -> 'debug')
 					? return('*' + tag_name + '*')
-					| return;
+					| return
 				*/
-				return '';
-			/if;
-			#output = .'strings' -> find( #language) -> find( #key);
+				if(#always) => {
+					return #key
+					log_critical('lang called with key that wasn\'t found. Key: ' + #key)
+				else
+					return string
+				}
+			}
+			#output = .'strings' -> find( #language) -> find( #key)
 
-			if(#output -> isa( 'tag'));
+			if(#output -> isa(::tag)) => {
 				// execute compund expression
-				#output = #output -> run;
-			/if;
-			if(#output -> size > 0 && #replace -> size > 0);
+				#output = #output -> run
+			}
+			if(#output -> size > 0 && #replace -> size > 0) => {
 				// replace placeholders with real values
-				if(!(#replace -> isa(::array)) && !(#replace -> isa(::map)) && !(#replace -> isa(::set)));
-					#replace = array( #replace);
-				/if;
-				iterate(#replace, local('replacement'));
+				if(!(#replace -> isa(::array)) && !(#replace -> isa(::map)) && !(#replace -> isa(::set))) => {
+					#replace = array( #replace)
+				}
+				local(loopcount = 0)
+				with replacement in #replace do => {
+					#loopcount += 1
 					// make sure we have a pair
-					if(!(#replacement -> isa( 'pair')));
-						#replacement = pair( '#' + loop_count + '#' = #replacement);
-					/if;
+					if(!(#replacement -> isa(::pair))) => {
+						#replacement = pair( '#' + #loopcount + '#' = #replacement)
+					}
 					// if we have a compund expression as replacement, execute the replacement first
-					if((#replacement -> value -> isa( 'tag')));
-						(#replacement -> value) = #replacement -> value -> run;
-					/if;
-					#output -> replace( #replacement -> name, #replacement -> value);
-				/iterate;
-			/if;
-		/if;
+					if((#replacement -> value -> isa(::tag))) => {
+						(#replacement -> value) = #replacement -> value -> run
+					}
+					#output -> replace( #replacement -> name, #replacement -> value)
+				}
+			}
+		}
 
-		return #output;
+		return #output
 
 	}
 
 	public getstring(
-		key::string,
-		-language::string = '',
-		-replace = ''
-	) => .getstring(#key, #language, #replace)
+		key::any,
+		-language::string = string,
+		-replace = string,
+		-always::boolean = false
+	) => .getstring(#key, #language, #replace, #always)
 
 	public getstring(
-		-key::string,
-		-language::string = '',
-		-replace = ''
-	) => .getstring(#key, #language, #replace)
-
-	public getstring(
-		key::integer,
-		-language::string = '',
-		-replace = ''
-	) => .getstring(#key, #language, #replace)
-
-	public getstring(
-		-key::integer,
-		-language::string = '',
-		-replace = ''
-	) => .getstring(#key, #language, #replace)
+		-key::any,
+		-language::string = string,
+		-replace = string,
+		-always::boolean = false
+	) => .getstring(#key, #language, #replace, #always)
 
 	/**!
 	setlanguage
@@ -251,17 +253,17 @@ define knop_lang => type {
 		language::string
 	) => {
 
-		if(var( '_knop_data') -> type != 'map');
+		if(not var_defined('_knop_data')) => {
 			// page level caching
-			$_knop_data = map;
-		/if;
-		if(.validlanguage( #language));
-			.'currentlanguage' = #language;
+			var(_knop_data = map)
+		}
+		if(.validlanguage( #language)) => {
+			.'currentlanguage' = #language
 			// save page level language
-			$_knop_data -> insert('currentlanguage' = #language);
-		else;
-//			(self -> 'debug_trace') -> insert( tag_name + '### Could not set current language to ' + #language + ' since it does not exist in the lang object');
-		/if;
+			$_knop_data -> insert('currentlanguage' = #language)
+		else
+//			(self -> 'debug_trace') -> insert( tag_name + '### Could not set current language to ' + #language + ' since it does not exist in the lang object')
+		}
 	}
 
 	/**!
@@ -279,68 +281,71 @@ define knop_lang => type {
 	Autodetects and returns the most preferred language out of all available languages as specified by the browser's accept-language q-value.
 	**/
 	public browserlanguage() => {
-		local('browserlanguage' = string);
+		local(browserlanguage = string)
 
-		if(var( '_knop_data') -> type != 'map');
+		if(not var_defined('_knop_data')) => {
 			// page level caching
-			$_knop_data = map;
-		/if;
+			var(_knop_data = map)
+		}
 
-		if($_knop_data >> 'browserlanguage');
+		if($_knop_data >> 'browserlanguage') => {
 			// use page cache
-			#browserlanguage = $_knop_data -> find('browserlanguage');
+			#browserlanguage = $_knop_data -> find('browserlanguage')
 
-		else;
-			local('acceptlanguage' = web_request -> httpacceptlanguage);
-			local('browserlanguages' = array);
+		else
+			local(acceptlanguage = web_request -> httpacceptlanguage)
+			local(browserlanguages = array)
 
-			#acceptlanguage -> trim; // NOTE needed?
-//			(self -> 'debug_trace') -> insert( tag_name + '### Accept-Language: ' + #acceptlanguage);
-			#acceptlanguage = #acceptlanguage -> split( ',');
-			iterate(#acceptlanguage, local('language'));
-				#language = #language -> split( ';');
-				if(#language -> size == 1);
+			#acceptlanguage -> trim // NOTE needed?
+//			(self -> 'debug_trace') -> insert( tag_name + '### Accept-Language: ' + #acceptlanguage)
+			#acceptlanguage = #acceptlanguage -> split( ',')
+			with language in #acceptlanguage do => {
+				#language = #language -> split( ';')
+				if(#language -> size == 1) => {
 					// no q value specified, use default 1.0
-					#language -> insert( 'q=1.0');
-				/if;
-				(#language -> first) -> trim;
-				if(#language -> size >= 2 && #language -> first -> size > 0);
-					(#language -> get(2)) = (#language -> second) -> split( '=') -> last;
-					(#language -> second) -> trim;
-					#browserlanguages -> insert( decimal( (#language -> second)) = (#language -> first) );
-				/if;
-			/iterate;
-			#browserlanguages -> sort( true);
+					#language -> insert( 'q=1.0')
+				}
+				(#language -> first) -> trim
+				if(#language -> size >= 2 && #language -> first -> size > 0) => {
+					(#language -> get(2)) = (#language -> second) -> split( '=') -> last
+					(#language -> second) -> trim
+					#browserlanguages -> insert( decimal( (#language -> second)) = (#language -> first) )
+				}
+			}
+			#browserlanguages -> sort( true)
 
 			// find the most preferred language
-//			(self -> 'debug_trace') -> insert( tag_name + '### looking for matching languages ');
-			iterate(#browserlanguages, local('language'));
-				if(.validlanguage(#language -> second));
+//			(self -> 'debug_trace') -> insert( tag_name + '### looking for matching languages ')
+			local(languagetmp)
+			loop(#browserlanguages -> size) => {
+				#languagetmp = #browserlanguages -> get(loop_count)
+				if(.validlanguage(#languagetmp -> second)) => {
 					/// found a valid language
-					#browserlanguage = #language -> second;
-//					(self -> 'debug_trace') -> insert( tag_name + '### found valid language ' + #browserlanguage);
-					loop_abort;
-				/if;
-			/iterate;
-			if(#browserlanguage -> size == 0);
+					#browserlanguage = #languagetmp -> second
+//					(self -> 'debug_trace') -> insert( tag_name + '### found valid language ' + #browserlanguage)
+					loop_abort
+				}
+			}
+			if(#browserlanguage -> size == 0) => {
 				// no matching language found, try again without locale
-//				(self -> 'debug_trace') -> insert( tag_name + '### no valid language found, looking again without locale ' + #language);
-				iterate(#browserlanguages, local('language'));
-					(#language -> second) = (#language -> second) -> split( '-') -> first;
-					if(.validlanguage(#language -> second));
+//				(self -> 'debug_trace') -> insert( tag_name + '### no valid language found, looking again without locale ' + #language)
+				loop(#browserlanguages -> size) => {
+					#languagetmp = #browserlanguages -> get(loop_count)
+					(#languagetmp -> second) = (#languagetmp -> second) -> split( '-') -> first
+					if(.validlanguage(#languagetmp -> second)) => {
 						/// found a valid language
-						#browserlanguage = #language -> second;
-//						(self -> 'debug_trace') -> insert( tag_name + '### found valid language ' + #browserlanguage);
-						loop_abort;
-					/if;
-				/iterate;
-			/if;
-			$_knop_data -> insert('browserlanguage' = #browserlanguage);
-		/if;
+						#browserlanguage = #languagetmp -> second
+//						(self -> 'debug_trace') -> insert( tag_name + '### found valid language ' + #browserlanguage)
+						loop_abort
+					}
+				}
+			}
+			$_knop_data -> insert('browserlanguage' = #browserlanguage)
+		}
 
-//		self -> 'tagtime_tagname' = tag_name;
-//		self -> 'tagtime' = integer(#timer); // cast to integer to trigger onconvert and to "stop timer"
-		return #browserlanguage;
+//		self -> 'tagtime_tagname' = tag_name
+//		self -> 'tagtime' = integer(#timer) // cast to integer to trigger onconvert and to "stop timer"
+		return #browserlanguage
 	}
 
 	/**!
@@ -349,20 +354,20 @@ define knop_lang => type {
 	Parameters:
 	-language (optional) string or array of strings.
 	**/
-	public languages(language = '') => {
-		local('languages' = .'strings' -> keys -> asarray);
-		if(#language -> size > 0);
+	public languages(language = string) => {
+		local(languages = .'strings' -> keys -> asarray)
+		if(#language -> size > 0) => {
 
-			#language = #language -> ascopy;
+			#language = #language -> ascopy
 
-			!(#language -> isa( 'array')) ? #language = array(#language);
+			!(#language -> isa(::array)) ? #language = array(#language)
 
-			#languages -> sort;
-			#language -> sort;
+			#languages -> sort
+			#language -> sort
 			// get the languages that exist in both arrays
-			#languages = #languages -> intersection( #language);
-		/if;
-		return #languages;
+			#languages = #languages -> intersection( #language)
+		}
+		return #languages
 	}
 
 	/**!
@@ -371,26 +376,26 @@ define knop_lang => type {
 	**/
 	public keys() => {
 
-		if(!.'keys' -> isa( 'array'));
-			local('keysarray' = array);
-//			local('keysmap' = map); // NOTE not used?
-			local('keysarray_new' = array);
+		if(!.'keys' -> isa(::array)) => {
+			local(keysarray = array)
+//			local(keysmap = map) // NOTE not used?
+			local(keysarray_new = array)
 			// no cached result yet - create list of all keys
-			iterate(.'strings', local('strings_language'));
-				#keysarray_new = #strings_language -> value -> keys -> asarray;
-				#keysarray_new -> sort;
-				#keysarray -> sort;
+			with strings_language in .'strings' do => {
+				#keysarray_new = #strings_language -> keys -> asarray
+				#keysarray_new -> sort
+				#keysarray -> sort
 				// add the keys that are not already in #keysarray by using union
-				#keysarray = #keysarray -> union( #keysarray_new);
-			/iterate;
-			.'keys' = #keysarray;
-		/if;
-		return .'keys';
+				#keysarray = #keysarray -> union( #keysarray_new)
+			}
+			.'keys' = #keysarray
+		}
+		return .'keys'
 
 	}
 
 }
 
-log_critical('load knop_lang ended')
+//log_critical('loading knop_lang done')
 
 ?>

--- a/knop9/knoplibs/knop_user.lasso
+++ b/knop9/knoplibs/knop_user.lasso
@@ -1,5 +1,5 @@
 ﻿<?LassoScript
-log_critical('loading knop_user from LassoApp')
+log_critical('loading knop_user')
 
 /**!
 knop_user
@@ -89,6 +89,7 @@ Permissions can be read, create, update, delete, or application specific (for ex
 define knop_user => type {
 /*
 CHANGE NOTES
+	2012-07-20	JC	Added getpermission(array)
 	2012-07-02	JC	Replaced all old style if, inline and loop with code blocks
 	2012-07-02	JC	Fixed erroneous handling of addlock and clearlocks
 	2012-05-19	JC	Made sure id_user is always of type string
@@ -104,7 +105,7 @@ CHANGE NOTES
 */
 	parent knop_base
 
-	data public version = '2012-05-18'
+	data public version = '2012-07-20'
 	data public description = 'Custom type to handle user identification and authentication'
 
 	data public fields::array = array()
@@ -337,7 +338,7 @@ Parameters:\n\
 **/
 	public auth() => {
 
-		local('validlogin' = .'validlogin')
+		local('validlogin' = .validlogin)
 		local('client_fingerprint_now' = string)
 
 		if(#validlogin && .'allowsidejacking' == false) => {
@@ -415,6 +416,9 @@ Log in user. On successful login, all fields on the user record will be availabl
 				}
 
 				#db -> select(#searchparams)
+
+				#db -> error_code ? log_critical('Error in knop_user DB call ' + #db -> error_msg)
+
 //				..'_debug_trace' -> insert('knop_user -> login: Searching user db, ' (#db -> found_count) + ' found ' + (#db -> error_msg) + ' ' + (#db -> action_statement))
 
 				if(#db -> found_count == 1
@@ -431,7 +435,6 @@ Log in user. On successful login, all fields on the user record will be availabl
 							-cost = (.'costfield' -> size ? integer(#db -> field(.'costfield')) | .'costsize'), -cipher = (.'encrypt_cipher')) == true) => {
 
 							#validlogin = true
-
 						}
 
 					else(.'encrypt' && .'saltfield' -> size)
@@ -589,6 +592,39 @@ Returns true if user has permission to perform the specified action, false other
 	}
 
 /**!
+getpermission(array)
+Will compare permissions to the given array. Can have one of two optional params
+	-any will return true if any of the provided array params match a permission
+	-all will return tru only if all the given params have a match in the users permission map.
+**/
+	public getpermission(
+		permissions::array,
+		-any::boolean = true,
+		-all::boolean = false
+	) => {
+
+		#permissions -> size == 0 ? return false
+
+		if(.auth && #any) => {
+			local(permstatus = false)
+			#permissions -> foreach => {
+				local(perm = #1)
+				.'permissions' >> #perm ? #permstatus = .'permissions' -> find(#perm)
+				#permstatus ? return true
+			}
+		else(.auth && #all)
+			#permissions -> foreach => {
+				local(perm = #1)
+				not .'permissions' >> #perm ? return false
+				.'permissions' -> find(#perm) == false ? return false
+			}
+			return true
+		}
+		return false
+
+	}
+
+/**!
 Sets the user\'s permission to perform the specified action (true or false, or just the name of the permission
 **/
 	public setpermission(
@@ -612,13 +648,11 @@ Called by database object, adds the name of a database object that has been lock
 	public addlock(
 		dbname::any
 	) => {
-stdoutnl('knop_user addlock called ' + #dbname)
 //stdoutnl('knop_user addlock check ' + var(#dbname) -> type)
 		if(var(#dbname) -> isa(::knop_database)) => {
 //			..'_debug_trace' -> insert('knop_user -> addlock: adding database name  ' + #dbname)
 			.'dblocks' -> insert(#dbname)
 		}
-stdoutnl('knop_user addlock dblocks ' + .'dblocks')
 	}
 
 	public addlock(
@@ -642,7 +676,7 @@ Clears all database locks that has been set by this user.
 //				if(var(loop_value) -> isa(::knop_database)) => {
 				protect => {
 					handle_error => {
-						log_critical('Error on clearlocks ' + error_msg)
+						log_critical('Error on knop_user clearlocks ' + error_msg)
 					}
 					#thislock -> clearlocks(.'id_user')
 					#cleared_dbs -> insert(#locks)
@@ -673,7 +707,7 @@ Returns an encrypted fingerprint based on client_ip and client_type.
 
 }
 
-log_critical('loading knop_user done')
+//log_critical('loading knop_user done')
 
 
 ?>


### PR DESCRIPTION
knop_base:
Major code cleanup of minor details.
Removed all semicolons
Changed local('xyz' to local(xyz
Replaced += with -> append
Changed old style if to brackets
Replaced iterate with query expression
Improved speed for method varname. Prev: ca 500 micros to run, now ca
55 micros. Note that varname does not work if the knop object is stored
in a local

knop_cache:
Replaced all iterate with query expr. Other minor code changes. Fixed
misplaced curly brackets around named signature calls

knop_database:
Changed remaining iterate to query
Making sure that capturesearchvars run on the first resultset when
called using select
Bug fix, making sure maxrecords is always an integer even when fed all
or 'all'
Replaced all old style if, inline and loop with code blocks
Commented out method varname to be used from knop_base instead
Fixed erroneous handling of addlock and clearlocks
Fixed bug that would allow capturesearchvars to populate lockfield
values despite the lock being obsolete

knop_form:
Changed encode_html(#requiredmarker) to #requiredmarker
Changed renderform to use #labelstart##labelend# instead of #label#.
This to enable #required# to be part of the <label>text</label> code
Fixes in renderhtml that contained tracking code no longer needed. Also
changed replace #label# calls that should have been #required#
Changed remaining isa('xxxx') to isa(::xxxx)
Fixed bug preventing hint on input type text field to work properly
Expanded support for input type text to include 'text', 'url', 'email',
'number', 'tel'
Changing errorclass so that it defaults to "error"
Added support for helpblock and error class marking where requested
Added support for bootstrap markup of checkbox. New param -bootstrap in
render_form
Fixed erroneous handling of addlock and clearlocks
Changed all iterate to query expr. Changed all += to append. Set br to
br /
Tweaks to make knop_form -> process work

knop_grid:
Fixed bug preventing quicksearch hint and input field to work properly
Changed old style if to Lasso 9 proper. Removed quotes from local
declarations. Replaced .'xxx' with 'xxx. Replaced iterate with query
expression. Replaced += with append.
Added support for bootstrap quicksearch form
Changed -> type == 'xxx' to -> isa(::xxx)

knop_lang:
Add log_critical for keys that wasn't found and if the -always flag is
set
Minor cleanup. Should mean an ever so small speed gain.
Added param always to getstring. Will always return a value. If the key
is not found will return the keyvalue itself
Changed all iterate to query expr or loop. Removed all semicolons.
Changed all old style if to code blocks.

knop_nav:
Added support for divider list item in bootstrap
Added param raw
Fixes for bootstrap rendering
Minor tweak to getlocation adding knop_trim
Fixed bug that was using type as a reference instead of a copy in
method filename
Changed += to append. Changed iterate to query expr. or loop.
Changed local('filename' = null) to local('filename' = string)

knop_user:
Added getpermission(array)
Replaced all old style if, inline and loop with code blocks
Fixed erroneous handling of addlock and clearlocks

knop_utils;
Cleaned up code for knop_crypthash making sure it can take bytes as
input for string value and made it look better
Added knop_response_filepath
Enhancing knop_stripbackticks to deal with more than strings
knop_math_hexToDec; changed iterate to loop to speed it up
